### PR TITLE
[AIPMOPS-0] chore(pm): promote active-state lifecycle baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,10 @@
 .AppleDouble
 Thumbs.db
 Desktop.ini
-
+__pycache__/
+*.pyc
+.aipm/state/
+.aipm/worktrees/
+.claude/settings.json
+.claude/worktrees/
+.codex/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,45 +1,3 @@
-# AIPM Issue-Driven Operating Rules
-
-This repository is used for daily AIPM project operations.
-
-## Trigger Phrases
-- `[PM]` (case-insensitive: `[pm]`, `[Pm]`, etc.) activates issue-driven lifecycle (see below).
-- `[AIPM-MAJOR]` or `major/request instruction` are aliases for `[PM]`.
-- `[AIPM-CHECK] #<issue-number>` for status confirmation.
-
-Without `[PM]`: execute directly, no issue tracking.
-
-## Execution Flow (when `[PM]` is active)
-1. Create or identify a GitHub issue.
-2. Assign labels using the label taxonomy in `docs/aipm-issue-workflow.md`.
-3. Auto-manage lifecycle logs per phase (issue-log calls are mandatory).
-4. Record PRD, execution plan, and result as issue comments.
-5. Include an issue key in all related commits and PR titles.
-
-## Issue Key Convention
-- Format: `AIPM-<issue-number>`
-- Example: `AIPM-12`
-
-## Branch Naming
-- Format: `<type>/<PREFIX>-<n>-<slug>`
-- Example: `feat/AIPM-17-governance-improvements`, `fix/AIPM-5-monitoring-alert`
-
-## Commit Convention
-- Subject format: `[AIPM-<n>] <type>(<scope>): <summary>`
-- Scope is optional: `[AIPM-<n>] <type>: <summary>` also valid
-- `Refs #<n>` for linked work
-- `Closes #<n>` for completion commit
-
-## Minimum Comment Log Format
-- `START`: scope, assumptions, done criteria
-- `PLAN` / `PRD`: requirements, execution plan
-- `PROGRESS`: what changed, blockers, next step
-- `RESULT`: outcome, verification, linked commit/PR
-
-## Helper Commands
-- Label bootstrap: `./scripts/setup-labels.sh`
-- Log comment: `./scripts/issue-log.sh <issue> <start|progress|end|prd|plan|result> [body-file] [--close]`
-
 <!-- AIPM-ISSUE-OPS:BEGIN -->
 ## AIPM Issue Ops (Managed)
 
@@ -57,13 +15,8 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 #### MODE 2 — CLOSEOUT
 `[pm] done` or `[pm] close` runs explicit closeout.
 1. Prepare result/retrospective document and update related docs
-2. Verify linked PR is merged (required by default)
-3. Run `pm-close` (modernization guard + `issue-log result --close`)
-
-#### SYNC CHECKPOINT
-`[pm]` alone runs sync checks for the current lifecycle state.
-- If an active issue exists: run progress/sync checks
-- If no active issue exists: run status/sync checks only (no new issue creation)
+2. Keep the result document in the active issue branch/worktree
+3. Run `pm-close --from-active --yes` to land + close
 
 #### MODE 3 — RELEASE
 `[pm] release [patch|minor|major]` runs standard tag/release automation (default: `patch`).
@@ -75,6 +28,11 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 6. Assign release-range issues to the matching milestone
 7. Verify release version == milestone version (1:1) + assignment parity
 8. Optionally backfill historical releases (`./scripts/pm-release.sh --backfill-all`)
+
+#### SYNC CHECKPOINT
+`[pm]` alone runs sync checks for the current lifecycle state.
+- If an active issue exists: run progress/sync checks
+- If no active issue exists: run status/sync checks only (no new issue creation)
 
 #### EXPLICIT CLOSE
 `[pm] done` or `[pm] close` explicitly triggers MODE 2.
@@ -91,12 +49,12 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 #### PM TRIGGER STANDARD MAPPING
 - `[pm] <title>` → `./scripts/pm-start.sh --title "<title>"`
 - `[pm]` → active-issue progress/sync checkpoint (`./scripts/pm-sync.sh` for manual audit)
-- `[pm] done|close` → `./scripts/pm-close.sh <issue> <result-file>` (defaults: merged PR + worktree cleanup required)
+- `[pm] done|close` → `./scripts/pm-close.sh --from-active --yes` (defaults: land + close)
 - `[pm] release [patch|minor|major]` → `./scripts/pm-release.sh [patch|minor|major]`
 
 #### ISSUE LABEL RULES (REQUIRED)
 - `[PM]` issue creation must use `./scripts/issue-create.sh`.
-- Forbidden: passing bare labels (`feature`, `epic`, `story`, `task`, `bug`, `chore`, `docs`, `refactor`) directly via `--label`.
+- Forbidden: passing bare labels(`feature`, `epic`, `story`, `task`, `bug`, `chore`, `docs`, `refactor`) directly via `--label`.
 - Standard label taxonomy: `type:*`, `status:*`, `priority:*`, `area:*`, `agent:*`.
 - Defaults: `type:task` when type is omitted, `status:todo` when status is omitted.
 - Multi-line bodies should use `--body-file` by default (`AIPM_ISSUE_BODY_MODE=file` in `.aipm/ops.env`).
@@ -140,11 +98,12 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 - `./scripts/setup-labels.sh`
 - `./scripts/issue-create.sh --title "[Task] ..." --body "..."`
 - `./scripts/pm-start.sh --title "[Task] ..." --start-file docs/start.md --plan-file docs/plan.md --progress-file docs/progress.md`
+- `./scripts/pm-sync.sh`
 - `./scripts/issue-log.sh <issue> start`
 - `./scripts/issue-log.sh <issue> plan`
 - `./scripts/issue-log.sh <issue> progress`
-- `./scripts/pm-sync.sh`
 - `./scripts/pm-modernize.sh --issue <issue> --result-file docs/result.md`
+- `./scripts/pm-close.sh --from-active --yes`
 - `./scripts/pm-close.sh <issue> docs/result.md`
 - `./scripts/check-pm-integrity.sh --state open --strict`
 - `./scripts/pm-release.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,3 @@
-# CLAUDE Rules
-
 <!-- AIPM-ISSUE-OPS:BEGIN -->
 ## AIPM Issue Ops (Managed)
 
@@ -17,13 +15,8 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 #### MODE 2 — CLOSEOUT
 `[pm] done` or `[pm] close` runs explicit closeout.
 1. Prepare result/retrospective document and update related docs
-2. Verify linked PR is merged (required by default)
-3. Run `pm-close` (modernization guard + `issue-log result --close`)
-
-#### SYNC CHECKPOINT
-`[pm]` alone runs sync checks for the current lifecycle state.
-- If an active issue exists: run progress/sync checks
-- If no active issue exists: run status/sync checks only (no new issue creation)
+2. Keep the result document in the active issue branch/worktree
+3. Run `pm-close --from-active --yes` to land + close
 
 #### MODE 3 — RELEASE
 `[pm] release [patch|minor|major]` runs standard tag/release automation (default: `patch`).
@@ -35,6 +28,11 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 6. Assign release-range issues to the matching milestone
 7. Verify release version == milestone version (1:1) + assignment parity
 8. Optionally backfill historical releases (`./scripts/pm-release.sh --backfill-all`)
+
+#### SYNC CHECKPOINT
+`[pm]` alone runs sync checks for the current lifecycle state.
+- If an active issue exists: run progress/sync checks
+- If no active issue exists: run status/sync checks only (no new issue creation)
 
 #### EXPLICIT CLOSE
 `[pm] done` or `[pm] close` explicitly triggers MODE 2.
@@ -51,12 +49,12 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 #### PM TRIGGER STANDARD MAPPING
 - `[pm] <title>` → `./scripts/pm-start.sh --title "<title>"`
 - `[pm]` → active-issue progress/sync checkpoint (`./scripts/pm-sync.sh` for manual audit)
-- `[pm] done|close` → `./scripts/pm-close.sh <issue> <result-file>` (defaults: merged PR + worktree cleanup required)
+- `[pm] done|close` → `./scripts/pm-close.sh --from-active --yes` (defaults: land + close)
 - `[pm] release [patch|minor|major]` → `./scripts/pm-release.sh [patch|minor|major]`
 
 #### ISSUE LABEL RULES (REQUIRED)
 - `[PM]` issue creation must use `./scripts/issue-create.sh`.
-- Forbidden: passing bare labels (`feature`, `epic`, `story`, `task`, `bug`, `chore`, `docs`, `refactor`) directly via `--label`.
+- Forbidden: passing bare labels(`feature`, `epic`, `story`, `task`, `bug`, `chore`, `docs`, `refactor`) directly via `--label`.
 - Standard label taxonomy: `type:*`, `status:*`, `priority:*`, `area:*`, `agent:*`.
 - Defaults: `type:task` when type is omitted, `status:todo` when status is omitted.
 - Multi-line bodies should use `--body-file` by default (`AIPM_ISSUE_BODY_MODE=file` in `.aipm/ops.env`).
@@ -100,11 +98,12 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 - `./scripts/setup-labels.sh`
 - `./scripts/issue-create.sh --title "[Task] ..." --body "..."`
 - `./scripts/pm-start.sh --title "[Task] ..." --start-file docs/start.md --plan-file docs/plan.md --progress-file docs/progress.md`
+- `./scripts/pm-sync.sh`
 - `./scripts/issue-log.sh <issue> start`
 - `./scripts/issue-log.sh <issue> plan`
 - `./scripts/issue-log.sh <issue> progress`
-- `./scripts/pm-sync.sh`
 - `./scripts/pm-modernize.sh --issue <issue> --result-file docs/result.md`
+- `./scripts/pm-close.sh --from-active --yes`
 - `./scripts/pm-close.sh <issue> docs/result.md`
 - `./scripts/check-pm-integrity.sh --state open --strict`
 - `./scripts/pm-release.sh`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Issue-driven lifecycle governance for AI-native development teams.
 
-One bootstrap command installs structured traceability, agent-agnostic dispatch, and PR merge gates across any GitHub repo.
+One bootstrap command installs structured traceability, agent-agnostic dispatch, and PM guardrails across any GitHub repo.
 
 ## What It Does
 
@@ -43,8 +43,9 @@ This installs:
 | `scripts/issue-create.sh` | Create normalized issues with canonical labels |
 | `scripts/issue-log.sh` | Post lifecycle logs (START/PROGRESS/RESULT) to GitHub Issues |
 | `scripts/pm-start.sh` | Start flow: issue + logs + branch/worktree |
-| `scripts/pm-close.sh` | Closeout flow: modernization guard + close |
-| `scripts/pm-sync.sh` | Audit state/worktree sync and orphan worktrees |
+| `scripts/pm-state.sh` | Shared active-issue state helpers |
+| `scripts/pm-close.sh` | Closeout flow: land + close from the active issue state |
+| `scripts/pm-sync.sh` | Sync summary based on active issue state |
 | `scripts/pm-modernize.sh` | Pre-close modernization checks and flag recording |
 | `scripts/pm-release.sh` | Release/milestone parity automation |
 | `scripts/check-pm-integrity.sh` | Audit `type:*` / `status:*` label integrity |
@@ -125,8 +126,8 @@ Add `[PM]` to your prompt in Claude Code or Codex CLI to activate issue-driven l
 
 Explicit closeout:
 1. Prepare result/retrospective and update related docs
-2. Verify linked PR merge (required by default)
-3. Run `pm-close` (`pm-modernize` + `issue-log result --close`)
+2. Keep the result document in the active issue branch/worktree
+3. Run `pm-close --from-active --yes` to land + close
 
 #### SYNC CHECKPOINT
 
@@ -210,6 +211,12 @@ Issue title prefix must match type: `[Epic]`, `[Feature]`, `[Story]`, `[Task]`, 
 
 Each command posts a structured comment to the GitHub issue.
 
+Standard close path:
+
+```bash
+./scripts/pm-close.sh --from-active --yes
+```
+
 ## Label Taxonomy
 
 4-axis system, 34+ labels total:
@@ -267,6 +274,7 @@ aipm-ops/
 │   ├── issue-log.sh              # Lifecycle log CLI
 │   ├── setup-labels.sh           # Label sync CLI
 │   ├── pm-start.sh               # PM start flow
+│   ├── pm-state.sh               # Active issue state helpers
 │   ├── pm-close.sh               # PM closeout flow
 │   ├── pm-sync.sh                # PM sync audit
 │   ├── pm-modernize.sh           # Modernization guard
@@ -279,6 +287,7 @@ aipm-ops/
 │   │   ├── issue-log.sh
 │   │   ├── setup-labels.sh
 │   │   ├── pm-start.sh
+│   │   ├── pm-state.sh
 │   │   ├── pm-close.sh
 │   │   ├── pm-sync.sh
 │   │   ├── pm-modernize.sh

--- a/docs/ai-sdlc-guide.md
+++ b/docs/ai-sdlc-guide.md
@@ -217,6 +217,7 @@ This installs:
 - `.github/ISSUE_TEMPLATE/aipm-major.md`
 - `.github/workflows/aipm-governance.yml`
 - Managed blocks appended to `AGENTS.md` and `CLAUDE.md`
+- Managed PM blocks map `[pm] done|close` to `./scripts/pm-close.sh --from-active --yes`
 - `git config core.hooksPath .githooks`
 
 ### 5.2 All Repos at Once

--- a/scripts/aipm-bootstrap-repo.sh
+++ b/scripts/aipm-bootstrap-repo.sh
@@ -225,8 +225,8 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 #### MODE 2 — CLOSEOUT
 `[pm] done` or `[pm] close` runs explicit closeout.
 1. Prepare result/retrospective document and update related docs
-2. Verify linked PR is merged (required by default)
-3. Run `pm-close` (modernization guard + `issue-log result --close`)
+2. Keep the result document in the active issue branch/worktree
+3. Run `pm-close --from-active --yes` to land + close
 
 #### MODE 3 — RELEASE
 `[pm] release [patch|minor|major]` runs standard tag/release automation (default: `patch`).
@@ -259,7 +259,7 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 #### PM TRIGGER STANDARD MAPPING
 - `[pm] <title>` → `./scripts/pm-start.sh --title "<title>"`
 - `[pm]` → active-issue progress/sync checkpoint (`./scripts/pm-sync.sh` for manual audit)
-- `[pm] done|close` → `./scripts/pm-close.sh <issue> <result-file>` (defaults: merged PR + worktree cleanup required)
+- `[pm] done|close` → `./scripts/pm-close.sh --from-active --yes` (defaults: land + close)
 - `[pm] release [patch|minor|major]` → `./scripts/pm-release.sh [patch|minor|major]`
 
 #### ISSUE LABEL RULES (REQUIRED)
@@ -308,11 +308,12 @@ When a prompt contains `[PM]` (case-insensitive), enable issue-driven lifecycle 
 - `./scripts/setup-labels.sh`
 - `./scripts/issue-create.sh --title "[Task] ..." --body "..."`
 - `./scripts/pm-start.sh --title "[Task] ..." --start-file docs/start.md --plan-file docs/plan.md --progress-file docs/progress.md`
+- `./scripts/pm-sync.sh`
 - `./scripts/issue-log.sh <issue> start`
 - `./scripts/issue-log.sh <issue> plan`
 - `./scripts/issue-log.sh <issue> progress`
-- `./scripts/pm-sync.sh`
 - `./scripts/pm-modernize.sh --issue <issue> --result-file docs/result.md`
+- `./scripts/pm-close.sh --from-active --yes`
 - `./scripts/pm-close.sh <issue> docs/result.md`
 - `./scripts/check-pm-integrity.sh --state open --strict`
 - `./scripts/pm-release.sh`
@@ -421,6 +422,7 @@ ensure_template_file "scripts/issue-log.sh" "scripts/issue-log.sh" "755"
 ensure_template_file "scripts/issue-create.sh" "scripts/issue-create.sh" "755"
 ensure_template_file "scripts/setup-labels.sh" "scripts/setup-labels.sh" "755"
 ensure_template_file "scripts/pm-start.sh" "scripts/pm-start.sh" "755"
+ensure_template_file "scripts/pm-state.sh" "scripts/pm-state.sh" "755"
 ensure_template_file "scripts/pm-close.sh" "scripts/pm-close.sh" "755"
 ensure_template_file "scripts/pm-sync.sh" "scripts/pm-sync.sh" "755"
 ensure_template_file "scripts/pm-modernize.sh" "scripts/pm-modernize.sh" "755"

--- a/scripts/check-pm-integrity.sh
+++ b/scripts/check-pm-integrity.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  ./scripts/check-pm-integrity.sh [--repo <owner/repo>] [--state <open|closed|all>] [--limit <n>] [--json] [--strict]
+  ./scripts/check-pm-integrity.sh [--repo <owner/repo>] [--state <open|closed|all>] [--limit <n>] [--json] [--strict] [--fix-active]
 
 Description:
   Audits issue label integrity for PM lifecycle governance.
@@ -53,6 +53,7 @@ state="open"
 limit="500"
 json=0
 strict=0
+fix_active=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -77,6 +78,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --strict)
       strict=1
+      shift
+      ;;
+    --fix-active)
+      fix_active=1
       shift
       ;;
     -h|--help)
@@ -109,6 +114,30 @@ require_cmd jq
 
 if [[ -z "$repo" ]]; then
   repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pm-state.sh
+source "$script_dir/pm-state.sh"
+
+if [[ "$fix_active" -eq 1 ]]; then
+  active_issue="$(pm_read_active_field issue 2>/dev/null || true)"
+  if [[ -n "$active_issue" ]]; then
+    active_json="$(gh issue view "$active_issue" --repo "$repo" --json number,title,state,labels)"
+    active_title="$(jq -r '.title' <<<"$active_json")"
+    active_state="$(jq -r '.state | ascii_downcase' <<<"$active_json")"
+    active_status_count="$(jq '[.labels[].name | ascii_downcase | select(startswith("status:"))] | length' <<<"$active_json")"
+    active_type_count="$(jq '[.labels[].name | ascii_downcase | select(startswith("type:"))] | length' <<<"$active_json")"
+    if [[ "$active_type_count" -eq 0 ]]; then
+      pm_add_type_label_if_missing "$repo" "$active_issue" "$active_title"
+    fi
+    if [[ "$active_state" == "open" && "$active_status_count" -eq 0 ]]; then
+      pm_set_issue_status_label "$repo" "$active_issue" "status:in-progress"
+    fi
+    if [[ "$active_state" == "closed" && "$active_status_count" -eq 0 ]]; then
+      pm_set_issue_status_label "$repo" "$active_issue" "status:done"
+    fi
+  fi
 fi
 
 issues_json="$(gh issue list --repo "$repo" --state "$state" --limit "$limit" --json number,title,state,url,labels)"

--- a/scripts/pm-close.sh
+++ b/scripts/pm-close.sh
@@ -5,9 +5,10 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  ./scripts/pm-close.sh <issue-number> <result-file> [--repo <owner/repo>] [--require-merged-pr|--no-require-merged-pr] [--cleanup-worktree|--no-cleanup-worktree]
+  ./scripts/pm-close.sh [--from-active] [--yes] <issue-number> <result-file> [--repo <owner/repo>] [--require-merged-pr|--no-require-merged-pr] [--close-only|--land-only] [--skip-commit] [--skip-push] [--skip-pr-create] [--skip-pr-merge] [--skip-worktree-cleanup]
 
 Examples:
+  ./scripts/pm-close.sh --from-active --yes
   ./scripts/pm-close.sh 218 docs/results/result-218-pm-done-label-normalization.md
   ./scripts/pm-close.sh 218 docs/results/result-218.md --no-require-merged-pr
 USAGE
@@ -25,143 +26,91 @@ normalize_bool() {
   esac
 }
 
-get_state_value() {
-  local file="$1"
-  local key="$2"
-  awk -F= -v target="$key" '$1 == target { print substr($0, index($0, "=") + 1); exit }' "$file"
+find_linked_pr() {
+  local repo="$1"
+  local issue_number="$2"
+  local pr_state="$3"
+  gh pr list --repo "$repo" --state "$pr_state" --search "#$issue_number" --limit 100 \
+    --json number,title,url,mergedAt,body \
+    | jq -c --arg issue "$issue_number" '
+      [ .[]
+        | select((((.title // "") + "\n" + (.body // "")) | test("(Refs|Closes|Fixes)[[:space:]]*(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#" + $issue + "\\b"; "i")))
+      ]
+      | sort_by(.mergedAt // "")
+      | last
+    '
 }
 
-find_worktree_for_branch() {
-  local target_branch="$1"
-  local current_path=""
-  while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        current_path="${line#worktree }"
-        ;;
-      branch\ refs/heads/*)
-        local branch_name="${line#branch refs/heads/}"
-        if [[ "$branch_name" == "$target_branch" ]]; then
-          printf '%s' "$current_path"
-          return 0
-        fi
-        ;;
-      "")
-        current_path=""
-        ;;
-    esac
-  done < <(git worktree list --porcelain)
+worktree_is_dirty() {
+  local path="$1"
+  [[ -n "$(git -C "$path" status --short 2>/dev/null)" ]]
+}
+
+path_tracked_in_worktree() {
+  local worktree_path="$1"
+  local repo_relative_path="$2"
+  git -C "$worktree_path" ls-files --error-unmatch -- "$repo_relative_path" >/dev/null 2>&1
+}
+
+safe_commit_all_changes() {
+  local path="$1"
+  local message="$2"
+  local body="$3"
+  git -C "$path" add -A
+  if [[ -n "$(git -C "$path" diff --cached --name-only)" ]]; then
+    git -C "$path" commit -m "$message" -m "$body"
+  fi
+}
+
+current_git_branch() {
+  git rev-parse --abbrev-ref HEAD 2>/dev/null || echo ""
+}
+
+current_git_dir() {
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+main_worktree_path() {
+  local current_branch current_dir main_worktree
+  current_branch="$(current_git_branch)"
+  current_dir="$(current_git_dir)"
+  main_worktree="$(pm_find_worktree_for_branch main || true)"
+  if [[ -n "$main_worktree" ]]; then
+    printf '%s' "$main_worktree"
+    return 0
+  fi
+  if [[ "$current_branch" == "main" ]]; then
+    printf '%s' "$current_dir"
+    return 0
+  fi
   return 1
 }
 
-find_worktree_for_issue_pattern() {
-  local pattern="$1"
-  local current_path=""
-  while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        current_path="${line#worktree }"
-        ;;
-      branch\ refs/heads/*)
-        local branch_name="${line#branch refs/heads/}"
-        if [[ "$branch_name" == *"$pattern"* ]]; then
-          printf '%s\n%s' "$branch_name" "$current_path"
-          return 0
-        fi
-        ;;
-      "")
-        current_path=""
-        ;;
-    esac
-  done < <(git worktree list --porcelain)
-  return 1
+ensure_main_worktree() {
+  local existing
+  existing="$(main_worktree_path || true)"
+  if [[ -n "$existing" ]]; then
+    printf '%s' "$existing"
+    return 0
+  fi
+  local temp_main
+  temp_main="${repo_root}/.aipm/worktrees/pm-close-main-sync"
+  mkdir -p "${repo_root}/.aipm/worktrees"
+  if [[ -e "$temp_main" ]]; then
+    rm -rf "$temp_main"
+  fi
+  git worktree add "$temp_main" main >/dev/null 2>&1
+  printf '%s' "$temp_main"
 }
 
-cleanup_issue_worktree() {
-  local issue_number_val="$1"
-  local repo_root_val="$2"
-  local state_dir_val="$3"
-  local state_file="${state_dir_val}/pm-issue-${issue_number_val}.env"
-  local issue_key_prefix_val="$4"
-
-  local tracked_branch=""
-  local tracked_worktree=""
-  local discovered_branch=""
-  local discovered_worktree=""
-  local issue_pattern=""
-  local issue_match=""
-
-  if [[ -f "$state_file" ]]; then
-    tracked_branch="$(get_state_value "$state_file" "branch")"
-    tracked_worktree="$(get_state_value "$state_file" "worktree_path")"
-  fi
-
-  if [[ -n "$tracked_branch" ]]; then
-    discovered_worktree="$(find_worktree_for_branch "$tracked_branch" || true)"
-    discovered_branch="$tracked_branch"
-  fi
-
-  if [[ -z "$discovered_worktree" ]]; then
-    issue_pattern="${issue_key_prefix_val}-${issue_number_val}-"
-    issue_match="$(find_worktree_for_issue_pattern "$issue_pattern" || true)"
-    if [[ -n "$issue_match" ]]; then
-      discovered_branch="$(printf '%s\n' "$issue_match" | sed -n '1p')"
-      discovered_worktree="$(printf '%s\n' "$issue_match" | sed -n '2p')"
-    fi
-  fi
-
-  if [[ -z "$discovered_worktree" && -n "$tracked_worktree" ]]; then
-    if git worktree list --porcelain | rg -Fq "worktree $tracked_worktree"; then
-      discovered_worktree="$tracked_worktree"
-      discovered_branch="${discovered_branch:-$tracked_branch}"
-    fi
-  fi
-
-  if [[ -z "$discovered_worktree" ]]; then
-    echo "[info] no registered worktree found for issue #$issue_number_val; cleanup skipped."
+merge_branch_into_main_worktree() {
+  local main_worktree="$1"
+  local branch_name="$2"
+  git -C "$main_worktree" checkout main >/dev/null 2>&1
+  if git -C "$main_worktree" merge-base --is-ancestor "$branch_name" main >/dev/null 2>&1; then
     return 0
   fi
-
-  if [[ "$discovered_worktree" == "$repo_root_val" ]]; then
-    echo "[info] skip cleanup for primary worktree: $discovered_worktree"
-    return 0
-  fi
-
-  if [[ ! -d "$discovered_worktree" ]]; then
-    echo "[warn] worktree path missing on disk: $discovered_worktree"
-    git worktree prune >/dev/null 2>&1 || true
-    echo "[ok] pruned stale worktree metadata."
-    return 0
-  fi
-
-  if [[ -n "$(git -C "$discovered_worktree" status --porcelain)" ]]; then
-    echo "error: dirty worktree detected for issue #$issue_number_val: $discovered_worktree" >&2
-    echo "hint: commit/stash/discard in that worktree, then rerun close; or bypass with --no-cleanup-worktree." >&2
-    return 1
-  fi
-
-  git worktree remove "$discovered_worktree"
-  git worktree prune >/dev/null 2>&1 || true
-  echo "[ok] cleaned worktree for issue #$issue_number_val: $discovered_worktree (${discovered_branch:-n/a})"
-  return 0
-}
-
-cleanup_state_artifacts() {
-  local issue_number_val="$1"
-  local state_dir_val="$2"
-  local issue_file="${state_dir_val}/pm-issue-${issue_number_val}.env"
-  local active_file="${state_dir_val}/pm-active.env"
-  local modernized_file="${state_dir_val}/modernized-${issue_number_val}.flag"
-  local active_issue=""
-
-  rm -f "$issue_file" "$modernized_file"
-
-  if [[ -f "$active_file" ]]; then
-    active_issue="$(get_state_value "$active_file" "issue_number")"
-    if [[ "$active_issue" == "$issue_number_val" ]]; then
-      rm -f "$active_file"
-    fi
-  fi
+  git -C "$main_worktree" merge --no-ff --no-edit "$branch_name"
 }
 
 if [[ $# -eq 1 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
@@ -169,21 +118,31 @@ if [[ $# -eq 1 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
   exit 0
 fi
 
-if [[ $# -lt 2 ]]; then
-  usage
-  exit 1
-fi
-
-issue_number="$1"
-result_file="$2"
-shift 2
+issue_number=""
+result_file=""
+from_active=0
+yes_mode=0
+close_only=0
+land_only=0
+skip_commit=0
+skip_push=0
+skip_pr_create=0
+skip_pr_merge=0
+skip_worktree_cleanup=0
 
 repo=""
 require_merged_pr="$(normalize_bool "${AIPM_PM_CLOSE_REQUIRE_MERGED_PR:-1}")"
-cleanup_worktree="$(normalize_bool "${AIPM_PM_CLOSE_CLEANUP_WORKTREE:-1}")"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --from-active)
+      from_active=1
+      shift
+      ;;
+    --yes)
+      yes_mode=1
+      shift
+      ;;
     --repo)
       [[ $# -lt 2 ]] && { echo "error: --repo requires a value" >&2; exit 1; }
       repo="$2"
@@ -197,12 +156,32 @@ while [[ $# -gt 0 ]]; do
       require_merged_pr=0
       shift
       ;;
-    --cleanup-worktree)
-      cleanup_worktree=1
+    --close-only)
+      close_only=1
       shift
       ;;
-    --no-cleanup-worktree)
-      cleanup_worktree=0
+    --land-only)
+      land_only=1
+      shift
+      ;;
+    --skip-commit)
+      skip_commit=1
+      shift
+      ;;
+    --skip-push)
+      skip_push=1
+      shift
+      ;;
+    --skip-pr-create)
+      skip_pr_create=1
+      shift
+      ;;
+    --skip-pr-merge)
+      skip_pr_merge=1
+      shift
+      ;;
+    --skip-worktree-cleanup)
+      skip_worktree_cleanup=1
       shift
       ;;
     -h|--help)
@@ -210,70 +189,274 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
-      echo "error: unknown argument: $1" >&2
-      usage
-      exit 1
+      if [[ -z "$issue_number" ]]; then
+        issue_number="$1"
+        shift
+      elif [[ -z "$result_file" ]]; then
+        result_file="$1"
+        shift
+      else
+        echo "error: unknown argument: $1" >&2
+        usage
+        exit 1
+      fi
       ;;
   esac
 done
+
+if [[ "$close_only" -eq 1 && "$land_only" -eq 1 ]]; then
+  echo "error: --close-only and --land-only are mutually exclusive" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pm-state.sh
+source "$script_dir/pm-state.sh"
+
+if [[ "$from_active" -eq 1 ]]; then
+  if [[ -z "$issue_number" ]]; then
+    issue_number="$(pm_read_active_field issue 2>/dev/null || true)"
+  fi
+  if [[ -z "$result_file" ]]; then
+    result_file="$(pm_read_active_field result_file 2>/dev/null || true)"
+  fi
+  if [[ -z "$repo" ]]; then
+    repo="$(pm_read_active_field repo 2>/dev/null || true)"
+  fi
+fi
+
+if [[ -z "$issue_number" || -z "$result_file" ]]; then
+  usage
+  exit 1
+fi
 
 if [[ ! "$issue_number" =~ ^[0-9]+$ ]]; then
   echo "error: issue-number must be numeric: $issue_number" >&2
   exit 1
 fi
 
-repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-cd "$repo_root"
-
-if [[ ! -f "$result_file" ]]; then
-  echo "error: result file not found: $result_file" >&2
-  exit 1
-fi
-
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-state_dir="${AIPM_STATE_DIR:-.aipm/state}"
-issue_key_prefix="AIPM"
-if [[ -f ".aipm/ops.env" ]]; then
-  # shellcheck disable=SC1091
-  source ".aipm/ops.env"
-fi
-issue_key_prefix="${ISSUE_KEY_PREFIX:-$issue_key_prefix}"
-
 if [[ -z "$repo" ]]; then
   repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
 fi
 
-if [[ "$require_merged_pr" -eq 1 ]]; then
-  merged_pr_json="$(
-    gh pr list --repo "$repo" --state merged --search "#$issue_number" --limit 100 \
-      --json number,title,url,mergedAt,body \
-      | jq -c --arg issue "$issue_number" '
-        [ .[]
-          | select((((.title // "") + "\n" + (.body // "")) | test("(Refs|Closes|Fixes)[[:space:]]*(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#" + $issue + "\\b"; "i")))
-        ]
-        | sort_by(.mergedAt)
-        | last
-      '
-  )"
+active_branch="$(pm_read_active_field branch 2>/dev/null || true)"
+active_worktree="$(pm_read_active_field worktree 2>/dev/null || true)"
+if [[ -z "$active_branch" ]]; then
+  active_branch="$(current_git_branch)"
+fi
+if [[ -z "$active_worktree" ]]; then
+  active_worktree="$(current_git_dir)"
+fi
 
+result_file_in_active_worktree=""
+if [[ -n "$active_worktree" && -n "$result_file" ]]; then
+  result_file_in_active_worktree="$(pm_resolve_path_in_worktree "$active_worktree" "$result_file")"
+fi
+
+blockers=()
+warnings=()
+temp_main_worktree=""
+
+if [[ ! -f "$result_file" ]]; then
+  blockers+=("result_file_missing:$result_file")
+fi
+if [[ -n "$active_branch" ]]; then
+  if ! git show-ref --verify --quiet "refs/heads/$active_branch"; then
+    blockers+=("active_branch_missing")
+  fi
+fi
+if [[ -n "$active_worktree" && ! -d "$active_worktree" ]]; then
+  blockers+=("active_worktree_missing")
+fi
+if [[ -f "$result_file" && -n "$result_file_in_active_worktree" && ! -f "$result_file_in_active_worktree" ]]; then
+  blockers+=("result_file_not_in_active_worktree:$result_file")
+fi
+if [[ -f "$result_file" && -n "$result_file_in_active_worktree" && -f "$result_file_in_active_worktree" ]]; then
+  result_abs="$(pm_abs_path "$result_file")"
+  result_in_worktree_abs="$(pm_abs_path "$result_file_in_active_worktree")"
+  if [[ "$result_abs" != "$result_in_worktree_abs" ]]; then
+    blockers+=("result_file_untracked_outside_active_branch:$result_file")
+  fi
+fi
+
+issue_state="$(gh issue view "$issue_number" --repo "$repo" --json state,title --jq '.state | ascii_downcase')"
+issue_title="$(gh issue view "$issue_number" --repo "$repo" --json state,title --jq '.title')"
+if [[ "$issue_state" != "open" ]]; then
+  blockers+=("issue_already_closed")
+fi
+
+if [[ -f "$result_file" ]] && ! grep -Eqi "modernization|modernized|현행화" "$result_file"; then
+  blockers+=("result_missing_modernization_section")
+fi
+if [[ -f "$result_file" && -n "$result_file_in_active_worktree" && -f "$result_file_in_active_worktree" ]]; then
+  if ! path_tracked_in_worktree "$active_worktree" "$result_file"; then
+    status_output="$(git -C "$active_worktree" status --short -- "$result_file" 2>/dev/null || true)"
+    if [[ -z "$status_output" ]]; then
+      blockers+=("result_file_untracked_outside_active_branch:$result_file")
+    fi
+  fi
+fi
+
+merged_pr_json="null"
+open_pr_json="null"
+if [[ "$require_merged_pr" -eq 1 ]]; then
+  merged_pr_json="$(find_linked_pr "$repo" "$issue_number" merged)"
+  open_pr_json="$(find_linked_pr "$repo" "$issue_number" open)"
+fi
+needs_land=0
+if [[ "$close_only" -ne 1 && "$require_merged_pr" -eq 1 ]]; then
   if [[ -z "$merged_pr_json" || "$merged_pr_json" == "null" ]]; then
-    echo "error: no merged PR found for issue #$issue_number in $repo" >&2
-    echo "hint: merge a PR that references this issue with Refs/Closes/Fixes #$issue_number, or run with --no-require-merged-pr." >&2
-    exit 1
+    needs_land=1
+  fi
+fi
+
+if [[ "$needs_land" -eq 1 ]]; then
+  if [[ -z "$active_branch" ]]; then
+    blockers+=("active_branch_missing")
+  fi
+  if [[ "$active_branch" == "main" && -d "$active_worktree" ]]; then
+    if worktree_is_dirty "$active_worktree"; then
+      blockers+=("branch_is_main_with_changes")
+    fi
+  fi
+fi
+
+if [[ "${#blockers[@]}" -gt 0 ]]; then
+  echo "error: pm-close preflight failed for issue #$issue_number" >&2
+  printf 'blocker=%s\n' "${blockers[@]}" >&2
+  exit 2
+fi
+
+if [[ "$needs_land" -eq 1 ]]; then
+  commit_message="[PP-${issue_number}] chore(pm): land closeout branch"
+  commit_body="Refs #${issue_number}"
+
+  if [[ -d "$active_worktree" ]]; then
+    if worktree_is_dirty "$active_worktree"; then
+      if [[ "$skip_commit" -eq 1 ]]; then
+        echo "error: pm-close land failed for issue #$issue_number" >&2
+        echo "blocker=dirty_worktree_uncommitted" >&2
+        exit 2
+      fi
+      safe_commit_all_changes "$active_worktree" "$commit_message" "$commit_body"
+    fi
   fi
 
+  if [[ "$skip_push" -eq 0 ]]; then
+    if ! git -C "$active_worktree" push -u origin "$active_branch"; then
+      echo "error: pm-close land failed for issue #$issue_number" >&2
+      echo "blocker=push_failed" >&2
+      exit 2
+    fi
+  fi
+
+  if [[ -z "$open_pr_json" || "$open_pr_json" == "null" ]]; then
+    if [[ "$skip_pr_create" -eq 1 ]]; then
+      echo "error: pm-close land failed for issue #$issue_number" >&2
+      echo "blocker=pr_create_failed" >&2
+      exit 2
+    fi
+    pr_body="$(mktemp)"
+    cat > "$pr_body" <<EOF
+## Summary
+- automated closeout land for issue #$issue_number
+
+## Notes
+- generated by pm-close
+
+Refs #$issue_number
+EOF
+    if ! gh pr create --repo "$repo" --base main --head "$active_branch" --title "$issue_title" --body-file "$pr_body" >/dev/null; then
+      rm -f "$pr_body"
+      echo "error: pm-close land failed for issue #$issue_number" >&2
+      echo "blocker=pr_create_failed" >&2
+      exit 2
+    fi
+    rm -f "$pr_body"
+    open_pr_json="$(find_linked_pr "$repo" "$issue_number" open)"
+  fi
+
+  if [[ "$skip_pr_merge" -eq 0 ]]; then
+    pr_number="$(jq -r '.number // ""' <<<"$open_pr_json")"
+    if [[ -z "$pr_number" ]]; then
+      echo "error: pm-close land failed for issue #$issue_number" >&2
+      echo "blocker=pr_create_failed" >&2
+      exit 2
+    fi
+    if ! gh pr merge "$pr_number" --repo "$repo" --squash --delete-branch >/dev/null; then
+      echo "error: pm-close land failed for issue #$issue_number" >&2
+      echo "blocker=pr_merge_failed" >&2
+      exit 2
+    fi
+
+    main_worktree="$(ensure_main_worktree || true)"
+    if [[ -z "$main_worktree" ]]; then
+      warnings+=("main_sync_failed")
+    else
+      if [[ "$main_worktree" == "${repo_root}/.aipm/worktrees/pm-close-main-sync" ]]; then
+        temp_main_worktree="$main_worktree"
+      fi
+      if ! merge_branch_into_main_worktree "$main_worktree" "$active_branch"; then
+        warnings+=("main_sync_failed")
+      else
+        if [[ "$skip_push" -eq 0 ]]; then
+          git -C "$main_worktree" push origin main >/dev/null 2>&1 || warnings+=("main_push_failed")
+        fi
+        if [[ "$skip_worktree_cleanup" -eq 0 && -n "$active_worktree" && -d "$active_worktree" ]]; then
+          current_abs="$(cd "$(pwd)" && pwd)"
+          active_abs="$(cd "$active_worktree" && pwd)"
+          if [[ "$current_abs" == "$active_abs" ]]; then
+            warnings+=("worktree_cleanup_skipped_current_shell")
+          else
+            git -C "$main_worktree" worktree remove "$active_worktree" --force >/dev/null 2>&1 || warnings+=("worktree_cleanup_failed")
+          fi
+        fi
+        git -C "$main_worktree" branch -D "$active_branch" >/dev/null 2>&1 || true
+      fi
+    fi
+
+    merged_pr_json="$(find_linked_pr "$repo" "$issue_number" merged)"
+  fi
+fi
+
+if [[ "$require_merged_pr" -eq 1 ]]; then
+  if [[ -z "$merged_pr_json" || "$merged_pr_json" == "null" ]]; then
+    echo "error: pm-close preflight failed for issue #$issue_number" >&2
+    echo "blocker=missing_merged_pr" >&2
+    exit 2
+  fi
   merged_pr_number="$(jq -r '.number' <<<"$merged_pr_json")"
   merged_pr_url="$(jq -r '.url' <<<"$merged_pr_json")"
   echo "[ok] merged PR linked: #$merged_pr_number ($merged_pr_url)"
 fi
 
-"$script_dir/pm-modernize.sh" --issue "$issue_number" --result-file "$result_file"
-
-if [[ "$cleanup_worktree" -eq 1 ]]; then
-  cleanup_issue_worktree "$issue_number" "$repo_root" "$state_dir" "$issue_key_prefix"
+if [[ "$land_only" -eq 0 ]]; then
+  modernize_cmd=("$script_dir/pm-modernize.sh" --issue "$issue_number" --result-file "$result_file")
+  if [[ "$yes_mode" -eq 1 ]]; then
+    modernize_cmd+=(--yes)
+  fi
+  "${modernize_cmd[@]}"
+  if [[ ! -f "$(pm_state_dir)/modernized-${issue_number}.flag" ]]; then
+    echo "error: pm-close preflight failed for issue #$issue_number" >&2
+    echo "blocker=missing_modernization_flag" >&2
+    exit 2
+  fi
+  AIPM_REPO="$repo" AIPM_MODERNIZED=1 "$script_dir/issue-log.sh" "$issue_number" result "$result_file" --close
+  AIPM_REPO="$repo"
+  pm_set_issue_status_label "$repo" "$issue_number" "status:done"
+  if pm_active_issue_matches "$issue_number"; then
+    pm_update_active_issue_status "closed"
+    pm_archive_active_issue
+  fi
 fi
 
-AIPM_REPO="$repo" AIPM_MODERNIZED=1 "$script_dir/issue-log.sh" "$issue_number" result "$result_file" --close
-cleanup_state_artifacts "$issue_number" "$state_dir"
+if [[ -n "$temp_main_worktree" && -d "$temp_main_worktree" ]]; then
+  git worktree remove "$temp_main_worktree" --force >/dev/null 2>&1 || true
+fi
 
 echo "[ok] PM close completed for issue #$issue_number"
+if [[ "${#warnings[@]}" -gt 0 ]]; then
+  printf 'warning=%s\n' "${warnings[@]}"
+fi

--- a/scripts/pm-modernize.sh
+++ b/scripts/pm-modernize.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  ./scripts/pm-modernize.sh --issue <issue-number> [--result-file <path>]
+  ./scripts/pm-modernize.sh --issue <issue-number> [--result-file <path>] [--yes]
 
 Examples:
   ./scripts/pm-modernize.sh --issue 218 --result-file docs/results/result-218.md
@@ -14,6 +14,7 @@ USAGE
 
 issue_number=""
 result_file=""
+yes_mode=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,6 +35,10 @@ while [[ $# -gt 0 ]]; do
       fi
       result_file="$2"
       shift 2
+      ;;
+    --yes)
+      yes_mode=1
+      shift
       ;;
     -h|--help)
       usage
@@ -83,7 +88,9 @@ cat <<'CHECKLIST'
 - Worktree cleanup and main integration status verified
 CHECKLIST
 
-if [[ -t 0 ]]; then
+if [[ "$yes_mode" -eq 1 ]]; then
+  :
+elif [[ -t 0 ]]; then
   echo "[confirm] If modernization is complete, type: MODERNIZED"
   printf "> "
   read -r ack
@@ -92,8 +99,8 @@ if [[ -t 0 ]]; then
     exit 1
   fi
 elif [[ "${AIPM_MODERNIZED:-0}" != "1" ]]; then
-  echo "error: non-interactive modernization requires AIPM_MODERNIZED=1." >&2
-  echo "hint: rerun in TTY or set AIPM_MODERNIZED=1 for automation." >&2
+  echo "error: non-interactive modernization requires explicit confirmation." >&2
+  echo "hint: rerun with --yes or set AIPM_MODERNIZED=1 for automation." >&2
   exit 1
 fi
 

--- a/scripts/pm-start.sh
+++ b/scripts/pm-start.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  ./scripts/pm-start.sh --title "<title>" [--body "<text>" | --body-file <path>] [--label <name>]... [--repo <owner/repo>] [--start-file <path>] [--plan-file <path>] [--progress-file <path>] [--branch <name>] [--worktree <path>] [--base <branch>] [--no-worktree] [--dry-run]
+  ./scripts/pm-start.sh --title "<title>" [--body "<text>" | --body-file <path>] [--label <name>]... [--repo <owner/repo>] [--start-file <path>] [--plan-file <path>] [--progress-file <path>] [--branch <name>] [--worktree <path>] [--base <branch>] [--no-worktree] [--budget-mode <warn|enforce|off>] [--budget-threshold <n>] [--force-budget] [--dry-run]
 
 Description:
   Standardized MODE 1 start flow for [pm] <title>.
@@ -18,6 +18,8 @@ Examples:
   ./scripts/pm-start.sh --title "[Task] Normalize PM mode docs" --label area:aipm --body "Goal and done criteria"
   ./scripts/pm-start.sh --title "[Feature] Add PM start wrapper" --start-file docs/start.md --plan-file docs/plan.md --progress-file docs/progress.md
   ./scripts/pm-start.sh --title "[Bug] Fix release note parser" --no-worktree
+  ./scripts/pm-start.sh --title "[Feature] Full pipeline automation" --budget-mode enforce
+  ./scripts/pm-start.sh --title "[Task] Full pipeline automation" --budget-mode enforce --force-budget
 USAGE
 }
 
@@ -37,6 +39,7 @@ infer_branch_type_from_title() {
   value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
   case "$value" in
     "[bug]"*) echo "fix" ;;
+    "[task]"*|"[test]"*) echo "task" ;;
     "[docs]"*) echo "docs" ;;
     "[chore]"*) echo "chore" ;;
     "[refactor]"*) echo "refactor" ;;
@@ -54,35 +57,63 @@ normalize_path() {
   fi
 }
 
-write_pm_state() {
-  local state_dir="$1"
-  local issue_number_val="$2"
-  local issue_key_val="$3"
-  local branch_val="$4"
-  local worktree_val="$5"
-  local create_worktree_val="$6"
-  local base_branch_val="$7"
-  local repo_root_val="$8"
-  local repo_val="$9"
-  local timestamp
+compute_scope_score() {
+  local text="$1"
+  local score=0
+  local chars=${#text}
 
-  mkdir -p "$state_dir"
-  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  if [[ "$chars" -ge 1200 ]]; then
+    score=$((score + 3))
+  elif [[ "$chars" -ge 700 ]]; then
+    score=$((score + 2))
+  elif [[ "$chars" -ge 350 ]]; then
+    score=$((score + 1))
+  fi
 
-  cat > "${state_dir}/pm-issue-${issue_number_val}.env" <<EOF
-# Managed by AIPM PM Start
-issue_number=${issue_number_val}
-issue_key=${issue_key_val}
-branch=${branch_val}
-worktree_path=${worktree_val}
-create_worktree=${create_worktree_val}
-base_branch=${base_branch_val}
-repo_root=${repo_root_val}
-repo=${repo_val}
-created_at=${timestamp}
-EOF
+  if printf '%s' "$text" | grep -Eqi '\b(parallel|pipeline|orchestr|multi[- ]?phase|end[- ]to[- ]end|full)\b'; then
+    score=$((score + 3))
+  fi
+  if printf '%s' "$text" | grep -Eqi '(병렬|파이프라인|오케스트|멀티|전 단계|전체 실행|엔드투엔드|풀런)'; then
+    score=$((score + 2))
+  fi
+  if printf '%s' "$text" | grep -Eqi '\b(phase|stage|agent|subagent|sub-agent|swarm)\b'; then
+    score=$((score + 2))
+  fi
+  if printf '%s' "$text" | grep -Eqi '(phase|stage|에이전트|서브에이전트|스웜)'; then
+    score=$((score + 1))
+  fi
 
-  cp "${state_dir}/pm-issue-${issue_number_val}.env" "${state_dir}/pm-active.env"
+  printf '%s' "$score"
+}
+
+run_budget_preflight() {
+  local title_val="$1"
+  local body_val="$2"
+  local mode_val="$3"
+  local threshold_val="$4"
+  local force_val="$5"
+  local combined=""
+  local scope_score=0
+
+  if [[ "$mode_val" == "off" ]]; then
+    return 0
+  fi
+
+  combined="$title_val"$'\n'"$body_val"
+  scope_score="$(compute_scope_score "$combined")"
+
+  if [[ "$scope_score" -lt "$threshold_val" ]]; then
+    return 0
+  fi
+
+  echo "[budget] scope-score=$scope_score (threshold=$threshold_val, mode=$mode_val)"
+  echo "[budget] large-scope work detected. Prefer a split session or explicit checkpointing."
+
+  if [[ "$mode_val" == "enforce" && "$force_val" -ne 1 ]]; then
+    echo "error: budget preflight blocked this start request." >&2
+    echo "hint: reduce scope or bypass explicitly with --force-budget." >&2
+    exit 2
+  fi
 }
 
 resolve_start_point() {
@@ -137,6 +168,9 @@ base_branch="${AIPM_PM_BASE_BRANCH:-main}"
 start_file=""
 plan_file=""
 progress_file=""
+budget_mode="${AIPM_PM_BUDGET_MODE:-warn}"
+budget_threshold="${AIPM_PM_BUDGET_THRESHOLD:-7}"
+force_budget=0
 labels=()
 tmp_files=()
 
@@ -213,6 +247,20 @@ while [[ $# -gt 0 ]]; do
       create_worktree=0
       shift
       ;;
+    --budget-mode)
+      [[ $# -lt 2 ]] && { echo "error: --budget-mode requires a value" >&2; exit 1; }
+      budget_mode="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
+      shift 2
+      ;;
+    --budget-threshold)
+      [[ $# -lt 2 ]] && { echo "error: --budget-threshold requires a value" >&2; exit 1; }
+      budget_threshold="$2"
+      shift 2
+      ;;
+    --force-budget)
+      force_budget=1
+      shift
+      ;;
     --dry-run)
       dry_run=1
       shift
@@ -250,6 +298,19 @@ if [[ -n "$body_file" && "$body_file" != "-" && ! -f "$body_file" ]]; then
   exit 1
 fi
 
+case "$budget_mode" in
+  warn|enforce|off) ;;
+  *)
+    echo "error: --budget-mode must be one of: warn, enforce, off" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! "$budget_threshold" =~ ^[0-9]+$ ]] || [[ "$budget_threshold" -lt 1 ]]; then
+  echo "error: --budget-threshold must be a positive integer" >&2
+  exit 1
+fi
+
 for phase_file in "$start_file" "$plan_file" "$progress_file"; do
   if [[ -n "$phase_file" && "$phase_file" != "-" && ! -f "$phase_file" ]]; then
     echo "error: phase file not found: $phase_file" >&2
@@ -261,6 +322,21 @@ repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$repo_root"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pm-state.sh
+source "$script_dir/pm-state.sh"
+
+preflight_body=""
+if [[ -n "$body" ]]; then
+  preflight_body="$body"
+elif [[ -n "$body_file" ]]; then
+  if [[ "$body_file" == "-" ]]; then
+    preflight_body=""
+  else
+    preflight_body="$(cat "$body_file")"
+  fi
+fi
+
+run_budget_preflight "$title" "$preflight_body" "$budget_mode" "$budget_threshold" "$force_budget"
 
 create_cmd=("$script_dir/issue-create.sh" --title "$title")
 if [[ -n "$body" ]]; then
@@ -270,8 +346,11 @@ if [[ -n "$body_file" ]]; then
   create_cmd+=(--body-file "$body_file")
 fi
 for label in "${labels[@]-}"; do
-  create_cmd+=(--label "$label")
+  if [[ "$label" != status:* ]]; then
+    create_cmd+=(--label "$label")
+  fi
 done
+create_cmd+=(--label "status:in-progress")
 if [[ -n "$repo" ]]; then
   create_cmd+=(--repo "$repo")
 fi
@@ -307,7 +386,12 @@ if [[ -f ".aipm/ops.env" ]]; then
 fi
 issue_key_prefix="${ISSUE_KEY_PREFIX:-$issue_key_prefix}"
 issue_key="${issue_key_prefix}-${issue_number}"
-state_dir="${AIPM_STATE_DIR:-.aipm/state}"
+issue_repo="$repo"
+if [[ -z "$issue_repo" ]]; then
+  issue_repo="${issue_url#https://github.com/}"
+  issue_repo="${issue_repo%/issues/*}"
+fi
+pm_set_issue_status_label "$issue_repo" "$issue_number" "status:in-progress"
 
 create_default_phase_file() {
   local phase="$1"
@@ -319,6 +403,9 @@ create_default_phase_file() {
       cat > "$file" <<EOF
 - Scope:
   - $title
+- Intent Contract:
+  - Execution Mode: implement-now
+  - Deliverable Interpretation: rendered artifacts (PDF/ePub/build outputs) unless explicitly stated otherwise
 - Assumptions:
   - TBD
 - Done Criteria:
@@ -411,13 +498,27 @@ if [[ "$create_worktree" -eq 1 ]]; then
   fi
 fi
 
-write_pm_state "$state_dir" "$issue_number" "$issue_key" "${branch_name:-}" "${worktree_path:-}" "$create_worktree" "$base_branch" "$repo_root" "${repo:-}"
+result_file="$(pm_default_result_file "$issue_number" "$title")"
+started_at="$(pm_iso_now)"
+pm_write_active_issue_state \
+  "$issue_number" \
+  "$title" \
+  "$branch_name" \
+  "$worktree_path" \
+  "$issue_repo" \
+  "${start_file:-}" \
+  "${plan_file:-}" \
+  "${progress_file:-}" \
+  "$result_file" \
+  "in_progress" \
+  "$started_at"
 
 echo "[ok] PM start completed for issue #$issue_number"
 echo "issue_url=$issue_url"
+echo "active_state=$(pm_active_issue_file)"
+echo "result_file=$result_file"
 if [[ "$create_worktree" -eq 1 ]]; then
   echo "branch=$branch_name"
   echo "worktree_path=$worktree_path"
   echo "next=cd \"$worktree_path\""
 fi
-echo "state_file=${state_dir}/pm-issue-${issue_number}.env"

--- a/scripts/pm-state.sh
+++ b/scripts/pm-state.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Shared PM lifecycle state helpers.
+set -euo pipefail
+
+pm_state_dir() {
+  printf '%s' "${AIPM_STATE_DIR:-.aipm/state}"
+}
+
+pm_active_issue_file() {
+  printf '%s/active-issue.json' "$(pm_state_dir)"
+}
+
+pm_last_active_issue_file() {
+  printf '%s/active-issue.last.json' "$(pm_state_dir)"
+}
+
+pm_iso_now() {
+  python3 - <<'PY'
+import datetime as dt
+print(dt.datetime.now(dt.timezone.utc).isoformat())
+PY
+}
+
+pm_slugify_title() {
+  local value="$1"
+  value="$(printf '%s' "$value" | sed -E 's/^[[:space:]]*\[[^]]+\][[:space:]]*//')"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+  value="$(printf '%s' "$value" | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+  if [[ -z "$value" ]]; then
+    value="work"
+  fi
+  printf '%s' "$value"
+}
+
+pm_infer_type_label_from_title() {
+  local value
+  value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
+    "[epic]"*) echo "type:epic" ;;
+    "[feature]"*) echo "type:feature" ;;
+    "[story]"*) echo "type:story" ;;
+    "[task]"*|"[test]"*) echo "type:task" ;;
+    "[bug]"*) echo "type:bug" ;;
+    "[chore]"*) echo "type:chore" ;;
+    "[docs]"*) echo "type:docs" ;;
+    "[refactor]"*) echo "type:refactor" ;;
+    "[prd]"*) echo "type:prd" ;;
+    "[plan]"*) echo "type:plan" ;;
+    "[result]"*) echo "type:result" ;;
+    *) echo "type:task" ;;
+  esac
+}
+
+pm_default_result_file() {
+  local issue_number="$1"
+  local title="$2"
+  printf 'docs/results/result-%s-%s.md' "$issue_number" "$(pm_slugify_title "$title")"
+}
+
+pm_write_active_issue_state() {
+  local issue_number="$1"
+  local title="$2"
+  local branch_name="$3"
+  local worktree_path="$4"
+  local repo="$5"
+  local start_file="$6"
+  local plan_file="$7"
+  local progress_file="$8"
+  local result_file="$9"
+  local status="${10}"
+  local started_at="${11}"
+  local active_file
+  active_file="$(pm_active_issue_file)"
+  mkdir -p "$(pm_state_dir)"
+  python3 - "$active_file" "$issue_number" "$title" "$branch_name" "$worktree_path" "$repo" "$start_file" "$plan_file" "$progress_file" "$result_file" "$status" "$started_at" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+(
+    active_file,
+    issue_number,
+    title,
+    branch_name,
+    worktree_path,
+    repo,
+    start_file,
+    plan_file,
+    progress_file,
+    result_file,
+    status,
+    started_at,
+) = sys.argv[1:13]
+
+payload = {
+    "issue": int(issue_number),
+    "title": title,
+    "branch": branch_name,
+    "worktree": worktree_path,
+    "repo": repo,
+    "started_at": started_at,
+    "updated_at": datetime.now(timezone.utc).isoformat(),
+    "start_file": start_file,
+    "plan_file": plan_file,
+    "progress_file": progress_file,
+    "result_file": result_file,
+    "status": status,
+}
+path = Path(active_file)
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+pm_update_active_issue_status() {
+  local next_status="$1"
+  local active_file
+  active_file="$(pm_active_issue_file)"
+  [[ -f "$active_file" ]] || return 0
+  python3 - "$active_file" "$next_status" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+path = Path(sys.argv[1])
+status = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["status"] = status
+payload["updated_at"] = datetime.now(timezone.utc).isoformat()
+path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+pm_read_active_field() {
+  local field="$1"
+  local active_file
+  active_file="$(pm_active_issue_file)"
+  if [[ ! -f "$active_file" ]]; then
+    return 1
+  fi
+  python3 - "$active_file" "$field" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+field = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+value = payload.get(field, "")
+if isinstance(value, (dict, list)):
+    import json as _json
+    print(_json.dumps(value, ensure_ascii=False))
+else:
+    print(value)
+PY
+}
+
+pm_read_active_json() {
+  local active_file
+  active_file="$(pm_active_issue_file)"
+  [[ -f "$active_file" ]] || return 1
+  cat "$active_file"
+}
+
+pm_active_issue_matches() {
+  local issue_number="$1"
+  local current_issue=""
+  current_issue="$(pm_read_active_field issue 2>/dev/null || true)"
+  [[ -n "$current_issue" && "$current_issue" == "$issue_number" ]]
+}
+
+pm_archive_active_issue() {
+  local active_file last_file
+  active_file="$(pm_active_issue_file)"
+  last_file="$(pm_last_active_issue_file)"
+  if [[ -f "$active_file" ]]; then
+    mkdir -p "$(pm_state_dir)"
+    mv "$active_file" "$last_file"
+  fi
+}
+
+pm_clear_active_issue() {
+  local active_file
+  active_file="$(pm_active_issue_file)"
+  [[ -f "$active_file" ]] || return 0
+  rm -f "$active_file"
+}
+
+pm_set_issue_status_label() {
+  local repo="$1"
+  local issue_number="$2"
+  local target_status="$3"
+  gh issue edit "$issue_number" --repo "$repo" \
+    --add-label "$target_status" \
+    --remove-label "status:todo" \
+    --remove-label "status:in-progress" \
+    --remove-label "status:blocked" \
+    --remove-label "status:review" \
+    --remove-label "status:done" \
+    --remove-label "status:wont-fix" \
+    --remove-label "status:duplicate" >/dev/null
+}
+
+pm_add_type_label_if_missing() {
+  local repo="$1"
+  local issue_number="$2"
+  local title="$3"
+  local labels_json type_count inferred_type
+  labels_json="$(gh issue view "$issue_number" --repo "$repo" --json labels)"
+  type_count="$(jq '[.labels[].name | ascii_downcase | select(startswith("type:"))] | length' <<<"$labels_json")"
+  if [[ "$type_count" -eq 0 ]]; then
+    inferred_type="$(pm_infer_type_label_from_title "$title")"
+    gh issue edit "$issue_number" --repo "$repo" --add-label "$inferred_type" >/dev/null
+  fi
+}
+
+pm_find_recent_issue_from_comments() {
+  local repo="$1"
+  local limit="${2:-30}"
+  local issues_json issue_number view_json
+  issues_json="$(gh issue list --repo "$repo" --state open --limit "$limit" --json number,title,updatedAt,url \
+    | jq 'sort_by(.updatedAt) | reverse')"
+  while IFS= read -r issue_number; do
+    [[ -n "$issue_number" ]] || continue
+    view_json="$(gh issue view "$issue_number" --repo "$repo" --json number,title,state,url,labels,comments)"
+    if jq -e '[.comments[].body | select(test("^### (START|PLAN|PROGRESS) \\| "; "m"))] | length > 0' <<<"$view_json" >/dev/null; then
+      printf '%s\n' "$view_json"
+      return 0
+    fi
+  done < <(jq -r '.[].number' <<<"$issues_json")
+  return 1
+}
+
+pm_find_worktree_for_branch() {
+  local target_branch="$1"
+  local current_path=""
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        current_path="${line#worktree }"
+        ;;
+      branch\ refs/heads/*)
+        local branch_name="${line#branch refs/heads/}"
+        if [[ "$branch_name" == "$target_branch" ]]; then
+          printf '%s' "$current_path"
+          return 0
+        fi
+        ;;
+      "")
+        current_path=""
+        ;;
+    esac
+  done < <(git worktree list --porcelain)
+  return 1
+}
+
+pm_abs_path() {
+  python3 - "$1" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).resolve())
+PY
+}
+
+pm_resolve_path_in_worktree() {
+  local worktree_path="$1"
+  local repo_relative_path="$2"
+  python3 - "$worktree_path" "$repo_relative_path" <<'PY'
+from pathlib import Path
+import sys
+
+worktree = Path(sys.argv[1]).resolve()
+relative = Path(sys.argv[2])
+print((worktree / relative).resolve())
+PY
+}

--- a/scripts/pm-sync.sh
+++ b/scripts/pm-sync.sh
@@ -5,97 +5,30 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  ./scripts/pm-sync.sh [--issue <issue-number>] [--state-dir <path>] [--worktree-root <path>] [--strict]
+  ./scripts/pm-sync.sh [--repo <owner/repo>] [--issue <n>] [--json]
 
 Description:
-  Audits PM issue state files against actual git worktree registrations.
-  - checks issue->branch->worktree mapping recorded by pm-start
-  - detects mapping mismatches and missing worktrees
-  - detects orphaned managed worktrees under .aipm/worktrees
-
-Options:
-  --issue <n>           Check only one issue
-  --state-dir <path>    State directory (default: .aipm/state)
-  --worktree-root <p>   Managed worktree root (default: .aipm/worktrees)
-  --strict              Exit 2 when violations are found
-
-Examples:
-  ./scripts/pm-sync.sh
-  ./scripts/pm-sync.sh --issue 218
-  ./scripts/pm-sync.sh --strict
+  Reports PM lifecycle sync state for the active issue or the most recent open issue
+  that already has START/PLAN/PROGRESS comments.
 USAGE
 }
 
-get_state_value() {
-  local file="$1"
-  local key="$2"
-  awk -F= -v target="$key" '$1 == target { print substr($0, index($0, "=") + 1); exit }' "$file"
-}
-
-find_worktree_for_branch() {
-  local target_branch="$1"
-  local current_path=""
-  while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        current_path="${line#worktree }"
-        ;;
-      branch\ refs/heads/*)
-        local branch_name="${line#branch refs/heads/}"
-        if [[ "$branch_name" == "$target_branch" ]]; then
-          printf '%s' "$current_path"
-          return 0
-        fi
-        ;;
-      "")
-        current_path=""
-        ;;
-    esac
-  done < <(git worktree list --porcelain)
-  return 1
-}
-
-normalize_path() {
-  local value="$1"
-  local root="$2"
-  if [[ "$value" = /* ]]; then
-    printf '%s' "$value"
-  else
-    printf '%s/%s' "$root" "$value"
-  fi
-}
-
-add_violation() {
-  local code="$1"
-  local message="$2"
-  violation_count=$((violation_count + 1))
-  printf '%s|%s\n' "$code" "$message" >>"$violations_file"
-}
-
-issue_filter=""
-strict=0
-state_dir=""
-worktree_root=""
+repo=""
+issue_number=""
+json_output=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
     --issue)
-      [[ $# -lt 2 ]] && { echo "error: --issue requires a value" >&2; exit 1; }
-      issue_filter="$2"
+      issue_number="$2"
       shift 2
       ;;
-    --state-dir)
-      [[ $# -lt 2 ]] && { echo "error: --state-dir requires a value" >&2; exit 1; }
-      state_dir="$2"
-      shift 2
-      ;;
-    --worktree-root)
-      [[ $# -lt 2 ]] && { echo "error: --worktree-root requires a value" >&2; exit 1; }
-      worktree_root="$2"
-      shift 2
-      ;;
-    --strict)
-      strict=1
+    --json)
+      json_output=1
       shift
       ;;
     -h|--help)
@@ -110,124 +43,212 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -n "$issue_filter" && ! "$issue_filter" =~ ^[0-9]+$ ]]; then
-  echo "error: --issue must be numeric: $issue_filter" >&2
-  exit 1
-fi
-
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$repo_root"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pm-state.sh
+source "$script_dir/pm-state.sh"
 
-state_dir="${state_dir:-${AIPM_STATE_DIR:-.aipm/state}}"
-worktree_root="${worktree_root:-${AIPM_WORKTREE_ROOT:-$repo_root/.aipm/worktrees}}"
-worktree_root="$(normalize_path "$worktree_root" "$repo_root")"
+if [[ -z "$repo" ]]; then
+  repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+fi
 
-violations_file="$(mktemp)"
-tracked_paths_file="$(mktemp)"
-trap 'rm -f "$violations_file" "$tracked_paths_file"' EXIT
+active_json=""
+issue_json=""
+source_mode="none"
 
-violation_count=0
-state_count=0
-checked_count=0
+if [[ -n "$issue_number" ]]; then
+  issue_json="$(gh issue view "$issue_number" --repo "$repo" --json number,title,state,url,labels,comments)"
+  source_mode="explicit"
+elif active_json="$(pm_read_active_json 2>/dev/null || true)"; [[ -n "$active_json" ]]; then
+  issue_number="$(jq -r '.issue' <<<"$active_json")"
+  issue_json="$(gh issue view "$issue_number" --repo "$repo" --json number,title,state,url,labels,comments)"
+  source_mode="active"
+else
+  issue_json="$(pm_find_recent_issue_from_comments "$repo" 30 || true)"
+  if [[ -n "$issue_json" ]]; then
+    issue_number="$(jq -r '.number' <<<"$issue_json")"
+    source_mode="discovered"
+  fi
+fi
 
-shopt -s nullglob
-state_files=("$state_dir"/pm-issue-*.env)
-shopt -u nullglob
-
-if [[ "${#state_files[@]}" -eq 0 ]]; then
-  echo "repo_root=$repo_root"
-  echo "state_dir=$state_dir"
-  echo "worktree_root=$worktree_root"
-  echo "state_files=0"
-  echo "issues_checked=0"
-  echo "violations=0"
-  echo "details=none"
+if [[ -z "$issue_json" ]]; then
+  if [[ "$json_output" -eq 1 ]]; then
+    jq -n --arg repo "$repo" '{
+      repo: $repo,
+      source: "none",
+      state: "attention",
+      next_action: "Start with [pm] <title>.",
+      checks: { active_issue: false }
+    }'
+  else
+    echo "state=attention"
+    echo "source=none"
+    echo "next_action=Start with [pm] <title>."
+  fi
   exit 0
 fi
 
-for state_file in "${state_files[@]}"; do
-  state_count=$((state_count + 1))
+issue_state="$(jq -r '.state | ascii_downcase' <<<"$issue_json")"
+title="$(jq -r '.title' <<<"$issue_json")"
+issue_url="$(jq -r '.url' <<<"$issue_json")"
+status_labels="$(jq -r '[.labels[].name | ascii_downcase | select(startswith("status:"))] | join(",")' <<<"$issue_json")"
+type_labels="$(jq -r '[.labels[].name | ascii_downcase | select(startswith("type:"))] | join(",")' <<<"$issue_json")"
+status_count="$(jq '[.labels[].name | ascii_downcase | select(startswith("status:"))] | length' <<<"$issue_json")"
+type_count="$(jq '[.labels[].name | ascii_downcase | select(startswith("type:"))] | length' <<<"$issue_json")"
+has_start="$(jq '[.comments[].body | select(test("^### START \\| "; "m"))] | length > 0' <<<"$issue_json")"
+has_plan="$(jq '[.comments[].body | select(test("^### PLAN \\| "; "m"))] | length > 0' <<<"$issue_json")"
+has_progress="$(jq '[.comments[].body | select(test("^### PROGRESS \\| "; "m"))] | length > 0' <<<"$issue_json")"
 
-  state_issue="$(get_state_value "$state_file" "issue_number")"
-  if [[ -z "$state_issue" ]]; then
-    state_issue="$(basename "$state_file" | sed -E 's/^pm-issue-([0-9]+)\.env$/\1/')"
-  fi
-
-  if [[ -n "$issue_filter" && "$state_issue" != "$issue_filter" ]]; then
-    continue
-  fi
-
-  checked_count=$((checked_count + 1))
-
-  state_branch="$(get_state_value "$state_file" "branch")"
-  state_worktree="$(get_state_value "$state_file" "worktree_path")"
-  state_create_worktree="$(get_state_value "$state_file" "create_worktree")"
-
-  if [[ "${state_create_worktree:-0}" != "1" ]]; then
-    continue
-  fi
-
-  if [[ -z "$state_branch" ]]; then
-    add_violation "missing_branch" "issue #$state_issue has empty branch in state ($state_file)"
-    continue
-  fi
-
-  if [[ -z "$state_worktree" ]]; then
-    add_violation "missing_worktree_path" "issue #$state_issue has empty worktree_path in state ($state_file)"
-    continue
-  fi
-
-  registered_worktree="$(find_worktree_for_branch "$state_branch" || true)"
-  if [[ -z "$registered_worktree" ]]; then
-    add_violation "branch_without_worktree" "issue #$state_issue branch '$state_branch' has no registered worktree"
-    continue
-  fi
-
-  printf '%s\n' "$registered_worktree" >>"$tracked_paths_file"
-
-  if [[ "$registered_worktree" != "$state_worktree" ]]; then
-    add_violation "state_path_mismatch" "issue #$state_issue branch '$state_branch' state='$state_worktree' actual='$registered_worktree'"
-  fi
-
-done
-
-if [[ -z "$issue_filter" ]]; then
-  current_path=""
-  while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        current_path="${line#worktree }"
-        ;;
-      "")
-        if [[ -n "$current_path" && "$current_path" == "$worktree_root"/* ]]; then
-          if ! grep -Fxq "$current_path" "$tracked_paths_file"; then
-            add_violation "orphan_worktree" "managed worktree without active PM state: $current_path"
-          fi
-        fi
-        current_path=""
-        ;;
-    esac
-  done < <(git worktree list --porcelain)
+branch_name=""
+worktree_path=""
+result_file=""
+active_present=0
+if [[ -n "$active_json" ]]; then
+  active_present=1
+  branch_name="$(jq -r '.branch // ""' <<<"$active_json")"
+  worktree_path="$(jq -r '.worktree // ""' <<<"$active_json")"
+  result_file="$(jq -r '.result_file // ""' <<<"$active_json")"
+fi
+if [[ -z "$result_file" ]]; then
+  result_file="$(pm_default_result_file "$issue_number" "$title")"
 fi
 
-echo "repo_root=$repo_root"
-echo "state_dir=$state_dir"
-echo "worktree_root=$worktree_root"
-echo "state_files=$state_count"
-echo "issues_checked=$checked_count"
-echo "violations=$violation_count"
+branch_exists=0
+worktree_exists=0
+result_exists=0
+merged_pr=0
+modernized=0
+if [[ -n "$branch_name" ]] && git show-ref --verify --quiet "refs/heads/$branch_name"; then
+  branch_exists=1
+fi
+if [[ -n "$worktree_path" ]] && [[ -d "$worktree_path" ]]; then
+  worktree_exists=1
+fi
+if [[ -f "$result_file" ]]; then
+  result_exists=1
+fi
+if gh pr list --repo "$repo" --state merged --search "#$issue_number" --limit 30 --json number | jq -e 'length > 0' >/dev/null; then
+  merged_pr=1
+fi
+if [[ -f "$(pm_state_dir)/modernized-${issue_number}.flag" ]]; then
+  modernized=1
+fi
 
-if [[ "$violation_count" -gt 0 ]]; then
-  while IFS= read -r line; do
-    [[ -z "$line" ]] && continue
-    code="${line%%|*}"
-    message="${line#*|}"
-    echo "- [$code] $message"
-  done <"$violations_file"
+summary_state="healthy"
+next_action="Continue implementation."
+blockers=()
+
+if [[ "$issue_state" != "open" ]]; then
+  summary_state="blocked"
+  blockers+=("issue_not_open")
+  next_action="Clear stale active issue state or start a new PM task."
+fi
+if [[ "$status_count" -ne 1 || "$type_count" -ne 1 ]]; then
+  if [[ "$summary_state" == "healthy" ]]; then
+    summary_state="attention"
+  fi
+  blockers+=("label_integrity")
+  next_action="Run ./scripts/check-pm-integrity.sh --fix-active or repair labels."
+fi
+if [[ "$has_start" != "true" || "$has_plan" != "true" || "$has_progress" != "true" ]]; then
+  if [[ "$summary_state" == "healthy" ]]; then
+    summary_state="attention"
+  fi
+  blockers+=("phase_logs_missing")
+  next_action="Post missing START/PLAN/PROGRESS logs."
+fi
+if [[ "$active_present" -eq 1 && ( "$branch_exists" -ne 1 || "$worktree_exists" -ne 1 ) ]]; then
+  summary_state="blocked"
+  blockers+=("branch_or_worktree_missing")
+  next_action="Restore the tracked worktree/branch or refresh active state."
+fi
+if [[ "$result_exists" -eq 1 && "$merged_pr" -ne 1 ]]; then
+  if [[ "$summary_state" == "healthy" ]]; then
+    summary_state="attention"
+  fi
+  blockers+=("pr_not_merged")
+  next_action="Run [pm] close to land the branch and close the issue."
+fi
+if [[ "$result_exists" -eq 1 && "$merged_pr" -eq 1 && "$modernized" -ne 1 ]]; then
+  if [[ "$summary_state" == "healthy" ]]; then
+    summary_state="attention"
+  fi
+  blockers+=("ready_to_close")
+  next_action="Run [pm] done or ./scripts/pm-close.sh --from-active --yes."
+fi
+
+if [[ "$json_output" -eq 1 ]]; then
+  jq -n \
+    --arg repo "$repo" \
+    --arg source "$source_mode" \
+    --arg state "$summary_state" \
+    --arg next_action "$next_action" \
+    --argjson issue "$issue_number" \
+    --arg title "$title" \
+    --arg url "$issue_url" \
+    --arg issue_state "$issue_state" \
+    --arg status_labels "$status_labels" \
+    --arg type_labels "$type_labels" \
+    --arg branch "$branch_name" \
+    --arg worktree "$worktree_path" \
+    --arg result_file "$result_file" \
+    --argjson active_issue "$( [[ "$active_present" -eq 1 ]] && echo true || echo false )" \
+    --argjson branch_exists "$( [[ "$branch_exists" -eq 1 ]] && echo true || echo false )" \
+    --argjson worktree_exists "$( [[ "$worktree_exists" -eq 1 ]] && echo true || echo false )" \
+    --argjson result_exists "$( [[ "$result_exists" -eq 1 ]] && echo true || echo false )" \
+    --argjson merged_pr "$( [[ "$merged_pr" -eq 1 ]] && echo true || echo false )" \
+    --argjson modernized "$( [[ "$modernized" -eq 1 ]] && echo true || echo false )" \
+    --argjson has_start "$has_start" \
+    --argjson has_plan "$has_plan" \
+    --argjson has_progress "$has_progress" \
+    --argjson blockers "$(printf '%s\n' "${blockers[@]-}" | jq -R -s 'split("\n") | map(select(length > 0))')" \
+    '{
+      repo: $repo,
+      source: $source,
+      state: $state,
+      next_action: $next_action,
+      issue: {
+        number: $issue,
+        title: $title,
+        state: $issue_state,
+        url: $url
+      },
+      checks: {
+        active_issue: $active_issue,
+        status_labels: $status_labels,
+        type_labels: $type_labels,
+        has_start: $has_start,
+        has_plan: $has_plan,
+        has_progress: $has_progress,
+        branch: $branch,
+        branch_exists: $branch_exists,
+        worktree: $worktree,
+        worktree_exists: $worktree_exists,
+        result_file: $result_file,
+        result_exists: $result_exists,
+        merged_pr: $merged_pr,
+        modernized: $modernized
+      },
+      blockers: $blockers
+    }'
 else
-  echo "details=none"
-fi
-
-if [[ "$strict" -eq 1 && "$violation_count" -gt 0 ]]; then
-  exit 2
+  echo "state=$summary_state"
+  echo "source=$source_mode"
+  echo "issue=$issue_number"
+  echo "title=$title"
+  echo "next_action=$next_action"
+  echo "checks:"
+  echo "- status_labels=${status_labels:-<none>}"
+  echo "- type_labels=${type_labels:-<none>}"
+  echo "- start=$has_start plan=$has_plan progress=$has_progress"
+  echo "- branch=${branch_name:-<none>} exists=$branch_exists"
+  echo "- worktree=${worktree_path:-<none>} exists=$worktree_exists"
+  echo "- result_file=$result_file exists=$result_exists"
+  echo "- merged_pr=$merged_pr modernized=$modernized"
+  if [[ "${#blockers[@]}" -gt 0 ]]; then
+    echo "blockers=${blockers[*]}"
+  else
+    echo "blockers=none"
+  fi
 fi

--- a/templates/aipm-ops/.gitignore
+++ b/templates/aipm-ops/.gitignore
@@ -4,4 +4,10 @@
 .AppleDouble
 Thumbs.db
 Desktop.ini
-
+__pycache__/
+*.pyc
+.aipm/state/
+.aipm/worktrees/
+.claude/settings.json
+.claude/worktrees/
+.codex/worktrees/

--- a/templates/aipm-ops/scripts/check-pm-integrity.sh
+++ b/templates/aipm-ops/scripts/check-pm-integrity.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  ./scripts/check-pm-integrity.sh [--repo <owner/repo>] [--state <open|closed|all>] [--limit <n>] [--json] [--strict]
+  ./scripts/check-pm-integrity.sh [--repo <owner/repo>] [--state <open|closed|all>] [--limit <n>] [--json] [--strict] [--fix-active]
 
 Description:
   Audits issue label integrity for PM lifecycle governance.
@@ -53,6 +53,7 @@ state="open"
 limit="500"
 json=0
 strict=0
+fix_active=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -77,6 +78,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --strict)
       strict=1
+      shift
+      ;;
+    --fix-active)
+      fix_active=1
       shift
       ;;
     -h|--help)
@@ -109,6 +114,30 @@ require_cmd jq
 
 if [[ -z "$repo" ]]; then
   repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pm-state.sh
+source "$script_dir/pm-state.sh"
+
+if [[ "$fix_active" -eq 1 ]]; then
+  active_issue="$(pm_read_active_field issue 2>/dev/null || true)"
+  if [[ -n "$active_issue" ]]; then
+    active_json="$(gh issue view "$active_issue" --repo "$repo" --json number,title,state,labels)"
+    active_title="$(jq -r '.title' <<<"$active_json")"
+    active_state="$(jq -r '.state | ascii_downcase' <<<"$active_json")"
+    active_status_count="$(jq '[.labels[].name | ascii_downcase | select(startswith("status:"))] | length' <<<"$active_json")"
+    active_type_count="$(jq '[.labels[].name | ascii_downcase | select(startswith("type:"))] | length' <<<"$active_json")"
+    if [[ "$active_type_count" -eq 0 ]]; then
+      pm_add_type_label_if_missing "$repo" "$active_issue" "$active_title"
+    fi
+    if [[ "$active_state" == "open" && "$active_status_count" -eq 0 ]]; then
+      pm_set_issue_status_label "$repo" "$active_issue" "status:in-progress"
+    fi
+    if [[ "$active_state" == "closed" && "$active_status_count" -eq 0 ]]; then
+      pm_set_issue_status_label "$repo" "$active_issue" "status:done"
+    fi
+  fi
 fi
 
 issues_json="$(gh issue list --repo "$repo" --state "$state" --limit "$limit" --json number,title,state,url,labels)"

--- a/templates/aipm-ops/scripts/pm-close.sh
+++ b/templates/aipm-ops/scripts/pm-close.sh
@@ -5,9 +5,10 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  ./scripts/pm-close.sh <issue-number> <result-file> [--repo <owner/repo>] [--require-merged-pr|--no-require-merged-pr] [--cleanup-worktree|--no-cleanup-worktree]
+  ./scripts/pm-close.sh [--from-active] [--yes] <issue-number> <result-file> [--repo <owner/repo>] [--require-merged-pr|--no-require-merged-pr] [--close-only|--land-only] [--skip-commit] [--skip-push] [--skip-pr-create] [--skip-pr-merge] [--skip-worktree-cleanup]
 
 Examples:
+  ./scripts/pm-close.sh --from-active --yes
   ./scripts/pm-close.sh 218 docs/results/result-218-pm-done-label-normalization.md
   ./scripts/pm-close.sh 218 docs/results/result-218.md --no-require-merged-pr
 USAGE
@@ -25,143 +26,91 @@ normalize_bool() {
   esac
 }
 
-get_state_value() {
-  local file="$1"
-  local key="$2"
-  awk -F= -v target="$key" '$1 == target { print substr($0, index($0, "=") + 1); exit }' "$file"
+find_linked_pr() {
+  local repo="$1"
+  local issue_number="$2"
+  local pr_state="$3"
+  gh pr list --repo "$repo" --state "$pr_state" --search "#$issue_number" --limit 100 \
+    --json number,title,url,mergedAt,body \
+    | jq -c --arg issue "$issue_number" '
+      [ .[]
+        | select((((.title // "") + "\n" + (.body // "")) | test("(Refs|Closes|Fixes)[[:space:]]*(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#" + $issue + "\\b"; "i")))
+      ]
+      | sort_by(.mergedAt // "")
+      | last
+    '
 }
 
-find_worktree_for_branch() {
-  local target_branch="$1"
-  local current_path=""
-  while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        current_path="${line#worktree }"
-        ;;
-      branch\ refs/heads/*)
-        local branch_name="${line#branch refs/heads/}"
-        if [[ "$branch_name" == "$target_branch" ]]; then
-          printf '%s' "$current_path"
-          return 0
-        fi
-        ;;
-      "")
-        current_path=""
-        ;;
-    esac
-  done < <(git worktree list --porcelain)
+worktree_is_dirty() {
+  local path="$1"
+  [[ -n "$(git -C "$path" status --short 2>/dev/null)" ]]
+}
+
+path_tracked_in_worktree() {
+  local worktree_path="$1"
+  local repo_relative_path="$2"
+  git -C "$worktree_path" ls-files --error-unmatch -- "$repo_relative_path" >/dev/null 2>&1
+}
+
+safe_commit_all_changes() {
+  local path="$1"
+  local message="$2"
+  local body="$3"
+  git -C "$path" add -A
+  if [[ -n "$(git -C "$path" diff --cached --name-only)" ]]; then
+    git -C "$path" commit -m "$message" -m "$body"
+  fi
+}
+
+current_git_branch() {
+  git rev-parse --abbrev-ref HEAD 2>/dev/null || echo ""
+}
+
+current_git_dir() {
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+main_worktree_path() {
+  local current_branch current_dir main_worktree
+  current_branch="$(current_git_branch)"
+  current_dir="$(current_git_dir)"
+  main_worktree="$(pm_find_worktree_for_branch main || true)"
+  if [[ -n "$main_worktree" ]]; then
+    printf '%s' "$main_worktree"
+    return 0
+  fi
+  if [[ "$current_branch" == "main" ]]; then
+    printf '%s' "$current_dir"
+    return 0
+  fi
   return 1
 }
 
-find_worktree_for_issue_pattern() {
-  local pattern="$1"
-  local current_path=""
-  while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        current_path="${line#worktree }"
-        ;;
-      branch\ refs/heads/*)
-        local branch_name="${line#branch refs/heads/}"
-        if [[ "$branch_name" == *"$pattern"* ]]; then
-          printf '%s\n%s' "$branch_name" "$current_path"
-          return 0
-        fi
-        ;;
-      "")
-        current_path=""
-        ;;
-    esac
-  done < <(git worktree list --porcelain)
-  return 1
+ensure_main_worktree() {
+  local existing
+  existing="$(main_worktree_path || true)"
+  if [[ -n "$existing" ]]; then
+    printf '%s' "$existing"
+    return 0
+  fi
+  local temp_main
+  temp_main="${repo_root}/.aipm/worktrees/pm-close-main-sync"
+  mkdir -p "${repo_root}/.aipm/worktrees"
+  if [[ -e "$temp_main" ]]; then
+    rm -rf "$temp_main"
+  fi
+  git worktree add "$temp_main" main >/dev/null 2>&1
+  printf '%s' "$temp_main"
 }
 
-cleanup_issue_worktree() {
-  local issue_number_val="$1"
-  local repo_root_val="$2"
-  local state_dir_val="$3"
-  local state_file="${state_dir_val}/pm-issue-${issue_number_val}.env"
-  local issue_key_prefix_val="$4"
-
-  local tracked_branch=""
-  local tracked_worktree=""
-  local discovered_branch=""
-  local discovered_worktree=""
-  local issue_pattern=""
-  local issue_match=""
-
-  if [[ -f "$state_file" ]]; then
-    tracked_branch="$(get_state_value "$state_file" "branch")"
-    tracked_worktree="$(get_state_value "$state_file" "worktree_path")"
-  fi
-
-  if [[ -n "$tracked_branch" ]]; then
-    discovered_worktree="$(find_worktree_for_branch "$tracked_branch" || true)"
-    discovered_branch="$tracked_branch"
-  fi
-
-  if [[ -z "$discovered_worktree" ]]; then
-    issue_pattern="${issue_key_prefix_val}-${issue_number_val}-"
-    issue_match="$(find_worktree_for_issue_pattern "$issue_pattern" || true)"
-    if [[ -n "$issue_match" ]]; then
-      discovered_branch="$(printf '%s\n' "$issue_match" | sed -n '1p')"
-      discovered_worktree="$(printf '%s\n' "$issue_match" | sed -n '2p')"
-    fi
-  fi
-
-  if [[ -z "$discovered_worktree" && -n "$tracked_worktree" ]]; then
-    if git worktree list --porcelain | rg -Fq "worktree $tracked_worktree"; then
-      discovered_worktree="$tracked_worktree"
-      discovered_branch="${discovered_branch:-$tracked_branch}"
-    fi
-  fi
-
-  if [[ -z "$discovered_worktree" ]]; then
-    echo "[info] no registered worktree found for issue #$issue_number_val; cleanup skipped."
+merge_branch_into_main_worktree() {
+  local main_worktree="$1"
+  local branch_name="$2"
+  git -C "$main_worktree" checkout main >/dev/null 2>&1
+  if git -C "$main_worktree" merge-base --is-ancestor "$branch_name" main >/dev/null 2>&1; then
     return 0
   fi
-
-  if [[ "$discovered_worktree" == "$repo_root_val" ]]; then
-    echo "[info] skip cleanup for primary worktree: $discovered_worktree"
-    return 0
-  fi
-
-  if [[ ! -d "$discovered_worktree" ]]; then
-    echo "[warn] worktree path missing on disk: $discovered_worktree"
-    git worktree prune >/dev/null 2>&1 || true
-    echo "[ok] pruned stale worktree metadata."
-    return 0
-  fi
-
-  if [[ -n "$(git -C "$discovered_worktree" status --porcelain)" ]]; then
-    echo "error: dirty worktree detected for issue #$issue_number_val: $discovered_worktree" >&2
-    echo "hint: commit/stash/discard in that worktree, then rerun close; or bypass with --no-cleanup-worktree." >&2
-    return 1
-  fi
-
-  git worktree remove "$discovered_worktree"
-  git worktree prune >/dev/null 2>&1 || true
-  echo "[ok] cleaned worktree for issue #$issue_number_val: $discovered_worktree (${discovered_branch:-n/a})"
-  return 0
-}
-
-cleanup_state_artifacts() {
-  local issue_number_val="$1"
-  local state_dir_val="$2"
-  local issue_file="${state_dir_val}/pm-issue-${issue_number_val}.env"
-  local active_file="${state_dir_val}/pm-active.env"
-  local modernized_file="${state_dir_val}/modernized-${issue_number_val}.flag"
-  local active_issue=""
-
-  rm -f "$issue_file" "$modernized_file"
-
-  if [[ -f "$active_file" ]]; then
-    active_issue="$(get_state_value "$active_file" "issue_number")"
-    if [[ "$active_issue" == "$issue_number_val" ]]; then
-      rm -f "$active_file"
-    fi
-  fi
+  git -C "$main_worktree" merge --no-ff --no-edit "$branch_name"
 }
 
 if [[ $# -eq 1 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
@@ -169,21 +118,31 @@ if [[ $# -eq 1 && ( "$1" == "-h" || "$1" == "--help" ) ]]; then
   exit 0
 fi
 
-if [[ $# -lt 2 ]]; then
-  usage
-  exit 1
-fi
-
-issue_number="$1"
-result_file="$2"
-shift 2
+issue_number=""
+result_file=""
+from_active=0
+yes_mode=0
+close_only=0
+land_only=0
+skip_commit=0
+skip_push=0
+skip_pr_create=0
+skip_pr_merge=0
+skip_worktree_cleanup=0
 
 repo=""
 require_merged_pr="$(normalize_bool "${AIPM_PM_CLOSE_REQUIRE_MERGED_PR:-1}")"
-cleanup_worktree="$(normalize_bool "${AIPM_PM_CLOSE_CLEANUP_WORKTREE:-1}")"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --from-active)
+      from_active=1
+      shift
+      ;;
+    --yes)
+      yes_mode=1
+      shift
+      ;;
     --repo)
       [[ $# -lt 2 ]] && { echo "error: --repo requires a value" >&2; exit 1; }
       repo="$2"
@@ -197,12 +156,32 @@ while [[ $# -gt 0 ]]; do
       require_merged_pr=0
       shift
       ;;
-    --cleanup-worktree)
-      cleanup_worktree=1
+    --close-only)
+      close_only=1
       shift
       ;;
-    --no-cleanup-worktree)
-      cleanup_worktree=0
+    --land-only)
+      land_only=1
+      shift
+      ;;
+    --skip-commit)
+      skip_commit=1
+      shift
+      ;;
+    --skip-push)
+      skip_push=1
+      shift
+      ;;
+    --skip-pr-create)
+      skip_pr_create=1
+      shift
+      ;;
+    --skip-pr-merge)
+      skip_pr_merge=1
+      shift
+      ;;
+    --skip-worktree-cleanup)
+      skip_worktree_cleanup=1
       shift
       ;;
     -h|--help)
@@ -210,70 +189,274 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     *)
-      echo "error: unknown argument: $1" >&2
-      usage
-      exit 1
+      if [[ -z "$issue_number" ]]; then
+        issue_number="$1"
+        shift
+      elif [[ -z "$result_file" ]]; then
+        result_file="$1"
+        shift
+      else
+        echo "error: unknown argument: $1" >&2
+        usage
+        exit 1
+      fi
       ;;
   esac
 done
+
+if [[ "$close_only" -eq 1 && "$land_only" -eq 1 ]]; then
+  echo "error: --close-only and --land-only are mutually exclusive" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pm-state.sh
+source "$script_dir/pm-state.sh"
+
+if [[ "$from_active" -eq 1 ]]; then
+  if [[ -z "$issue_number" ]]; then
+    issue_number="$(pm_read_active_field issue 2>/dev/null || true)"
+  fi
+  if [[ -z "$result_file" ]]; then
+    result_file="$(pm_read_active_field result_file 2>/dev/null || true)"
+  fi
+  if [[ -z "$repo" ]]; then
+    repo="$(pm_read_active_field repo 2>/dev/null || true)"
+  fi
+fi
+
+if [[ -z "$issue_number" || -z "$result_file" ]]; then
+  usage
+  exit 1
+fi
 
 if [[ ! "$issue_number" =~ ^[0-9]+$ ]]; then
   echo "error: issue-number must be numeric: $issue_number" >&2
   exit 1
 fi
 
-repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-cd "$repo_root"
-
-if [[ ! -f "$result_file" ]]; then
-  echo "error: result file not found: $result_file" >&2
-  exit 1
-fi
-
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-state_dir="${AIPM_STATE_DIR:-.aipm/state}"
-issue_key_prefix="AIPM"
-if [[ -f ".aipm/ops.env" ]]; then
-  # shellcheck disable=SC1091
-  source ".aipm/ops.env"
-fi
-issue_key_prefix="${ISSUE_KEY_PREFIX:-$issue_key_prefix}"
-
 if [[ -z "$repo" ]]; then
   repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
 fi
 
-if [[ "$require_merged_pr" -eq 1 ]]; then
-  merged_pr_json="$(
-    gh pr list --repo "$repo" --state merged --search "#$issue_number" --limit 100 \
-      --json number,title,url,mergedAt,body \
-      | jq -c --arg issue "$issue_number" '
-        [ .[]
-          | select((((.title // "") + "\n" + (.body // "")) | test("(Refs|Closes|Fixes)[[:space:]]*(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#" + $issue + "\\b"; "i")))
-        ]
-        | sort_by(.mergedAt)
-        | last
-      '
-  )"
+active_branch="$(pm_read_active_field branch 2>/dev/null || true)"
+active_worktree="$(pm_read_active_field worktree 2>/dev/null || true)"
+if [[ -z "$active_branch" ]]; then
+  active_branch="$(current_git_branch)"
+fi
+if [[ -z "$active_worktree" ]]; then
+  active_worktree="$(current_git_dir)"
+fi
 
+result_file_in_active_worktree=""
+if [[ -n "$active_worktree" && -n "$result_file" ]]; then
+  result_file_in_active_worktree="$(pm_resolve_path_in_worktree "$active_worktree" "$result_file")"
+fi
+
+blockers=()
+warnings=()
+temp_main_worktree=""
+
+if [[ ! -f "$result_file" ]]; then
+  blockers+=("result_file_missing:$result_file")
+fi
+if [[ -n "$active_branch" ]]; then
+  if ! git show-ref --verify --quiet "refs/heads/$active_branch"; then
+    blockers+=("active_branch_missing")
+  fi
+fi
+if [[ -n "$active_worktree" && ! -d "$active_worktree" ]]; then
+  blockers+=("active_worktree_missing")
+fi
+if [[ -f "$result_file" && -n "$result_file_in_active_worktree" && ! -f "$result_file_in_active_worktree" ]]; then
+  blockers+=("result_file_not_in_active_worktree:$result_file")
+fi
+if [[ -f "$result_file" && -n "$result_file_in_active_worktree" && -f "$result_file_in_active_worktree" ]]; then
+  result_abs="$(pm_abs_path "$result_file")"
+  result_in_worktree_abs="$(pm_abs_path "$result_file_in_active_worktree")"
+  if [[ "$result_abs" != "$result_in_worktree_abs" ]]; then
+    blockers+=("result_file_untracked_outside_active_branch:$result_file")
+  fi
+fi
+
+issue_state="$(gh issue view "$issue_number" --repo "$repo" --json state,title --jq '.state | ascii_downcase')"
+issue_title="$(gh issue view "$issue_number" --repo "$repo" --json state,title --jq '.title')"
+if [[ "$issue_state" != "open" ]]; then
+  blockers+=("issue_already_closed")
+fi
+
+if [[ -f "$result_file" ]] && ! grep -Eqi "modernization|modernized|현행화" "$result_file"; then
+  blockers+=("result_missing_modernization_section")
+fi
+if [[ -f "$result_file" && -n "$result_file_in_active_worktree" && -f "$result_file_in_active_worktree" ]]; then
+  if ! path_tracked_in_worktree "$active_worktree" "$result_file"; then
+    status_output="$(git -C "$active_worktree" status --short -- "$result_file" 2>/dev/null || true)"
+    if [[ -z "$status_output" ]]; then
+      blockers+=("result_file_untracked_outside_active_branch:$result_file")
+    fi
+  fi
+fi
+
+merged_pr_json="null"
+open_pr_json="null"
+if [[ "$require_merged_pr" -eq 1 ]]; then
+  merged_pr_json="$(find_linked_pr "$repo" "$issue_number" merged)"
+  open_pr_json="$(find_linked_pr "$repo" "$issue_number" open)"
+fi
+needs_land=0
+if [[ "$close_only" -ne 1 && "$require_merged_pr" -eq 1 ]]; then
   if [[ -z "$merged_pr_json" || "$merged_pr_json" == "null" ]]; then
-    echo "error: no merged PR found for issue #$issue_number in $repo" >&2
-    echo "hint: merge a PR that references this issue with Refs/Closes/Fixes #$issue_number, or run with --no-require-merged-pr." >&2
-    exit 1
+    needs_land=1
+  fi
+fi
+
+if [[ "$needs_land" -eq 1 ]]; then
+  if [[ -z "$active_branch" ]]; then
+    blockers+=("active_branch_missing")
+  fi
+  if [[ "$active_branch" == "main" && -d "$active_worktree" ]]; then
+    if worktree_is_dirty "$active_worktree"; then
+      blockers+=("branch_is_main_with_changes")
+    fi
+  fi
+fi
+
+if [[ "${#blockers[@]}" -gt 0 ]]; then
+  echo "error: pm-close preflight failed for issue #$issue_number" >&2
+  printf 'blocker=%s\n' "${blockers[@]}" >&2
+  exit 2
+fi
+
+if [[ "$needs_land" -eq 1 ]]; then
+  commit_message="[PP-${issue_number}] chore(pm): land closeout branch"
+  commit_body="Refs #${issue_number}"
+
+  if [[ -d "$active_worktree" ]]; then
+    if worktree_is_dirty "$active_worktree"; then
+      if [[ "$skip_commit" -eq 1 ]]; then
+        echo "error: pm-close land failed for issue #$issue_number" >&2
+        echo "blocker=dirty_worktree_uncommitted" >&2
+        exit 2
+      fi
+      safe_commit_all_changes "$active_worktree" "$commit_message" "$commit_body"
+    fi
   fi
 
+  if [[ "$skip_push" -eq 0 ]]; then
+    if ! git -C "$active_worktree" push -u origin "$active_branch"; then
+      echo "error: pm-close land failed for issue #$issue_number" >&2
+      echo "blocker=push_failed" >&2
+      exit 2
+    fi
+  fi
+
+  if [[ -z "$open_pr_json" || "$open_pr_json" == "null" ]]; then
+    if [[ "$skip_pr_create" -eq 1 ]]; then
+      echo "error: pm-close land failed for issue #$issue_number" >&2
+      echo "blocker=pr_create_failed" >&2
+      exit 2
+    fi
+    pr_body="$(mktemp)"
+    cat > "$pr_body" <<EOF
+## Summary
+- automated closeout land for issue #$issue_number
+
+## Notes
+- generated by pm-close
+
+Refs #$issue_number
+EOF
+    if ! gh pr create --repo "$repo" --base main --head "$active_branch" --title "$issue_title" --body-file "$pr_body" >/dev/null; then
+      rm -f "$pr_body"
+      echo "error: pm-close land failed for issue #$issue_number" >&2
+      echo "blocker=pr_create_failed" >&2
+      exit 2
+    fi
+    rm -f "$pr_body"
+    open_pr_json="$(find_linked_pr "$repo" "$issue_number" open)"
+  fi
+
+  if [[ "$skip_pr_merge" -eq 0 ]]; then
+    pr_number="$(jq -r '.number // ""' <<<"$open_pr_json")"
+    if [[ -z "$pr_number" ]]; then
+      echo "error: pm-close land failed for issue #$issue_number" >&2
+      echo "blocker=pr_create_failed" >&2
+      exit 2
+    fi
+    if ! gh pr merge "$pr_number" --repo "$repo" --squash --delete-branch >/dev/null; then
+      echo "error: pm-close land failed for issue #$issue_number" >&2
+      echo "blocker=pr_merge_failed" >&2
+      exit 2
+    fi
+
+    main_worktree="$(ensure_main_worktree || true)"
+    if [[ -z "$main_worktree" ]]; then
+      warnings+=("main_sync_failed")
+    else
+      if [[ "$main_worktree" == "${repo_root}/.aipm/worktrees/pm-close-main-sync" ]]; then
+        temp_main_worktree="$main_worktree"
+      fi
+      if ! merge_branch_into_main_worktree "$main_worktree" "$active_branch"; then
+        warnings+=("main_sync_failed")
+      else
+        if [[ "$skip_push" -eq 0 ]]; then
+          git -C "$main_worktree" push origin main >/dev/null 2>&1 || warnings+=("main_push_failed")
+        fi
+        if [[ "$skip_worktree_cleanup" -eq 0 && -n "$active_worktree" && -d "$active_worktree" ]]; then
+          current_abs="$(cd "$(pwd)" && pwd)"
+          active_abs="$(cd "$active_worktree" && pwd)"
+          if [[ "$current_abs" == "$active_abs" ]]; then
+            warnings+=("worktree_cleanup_skipped_current_shell")
+          else
+            git -C "$main_worktree" worktree remove "$active_worktree" --force >/dev/null 2>&1 || warnings+=("worktree_cleanup_failed")
+          fi
+        fi
+        git -C "$main_worktree" branch -D "$active_branch" >/dev/null 2>&1 || true
+      fi
+    fi
+
+    merged_pr_json="$(find_linked_pr "$repo" "$issue_number" merged)"
+  fi
+fi
+
+if [[ "$require_merged_pr" -eq 1 ]]; then
+  if [[ -z "$merged_pr_json" || "$merged_pr_json" == "null" ]]; then
+    echo "error: pm-close preflight failed for issue #$issue_number" >&2
+    echo "blocker=missing_merged_pr" >&2
+    exit 2
+  fi
   merged_pr_number="$(jq -r '.number' <<<"$merged_pr_json")"
   merged_pr_url="$(jq -r '.url' <<<"$merged_pr_json")"
   echo "[ok] merged PR linked: #$merged_pr_number ($merged_pr_url)"
 fi
 
-"$script_dir/pm-modernize.sh" --issue "$issue_number" --result-file "$result_file"
-
-if [[ "$cleanup_worktree" -eq 1 ]]; then
-  cleanup_issue_worktree "$issue_number" "$repo_root" "$state_dir" "$issue_key_prefix"
+if [[ "$land_only" -eq 0 ]]; then
+  modernize_cmd=("$script_dir/pm-modernize.sh" --issue "$issue_number" --result-file "$result_file")
+  if [[ "$yes_mode" -eq 1 ]]; then
+    modernize_cmd+=(--yes)
+  fi
+  "${modernize_cmd[@]}"
+  if [[ ! -f "$(pm_state_dir)/modernized-${issue_number}.flag" ]]; then
+    echo "error: pm-close preflight failed for issue #$issue_number" >&2
+    echo "blocker=missing_modernization_flag" >&2
+    exit 2
+  fi
+  AIPM_REPO="$repo" AIPM_MODERNIZED=1 "$script_dir/issue-log.sh" "$issue_number" result "$result_file" --close
+  AIPM_REPO="$repo"
+  pm_set_issue_status_label "$repo" "$issue_number" "status:done"
+  if pm_active_issue_matches "$issue_number"; then
+    pm_update_active_issue_status "closed"
+    pm_archive_active_issue
+  fi
 fi
 
-AIPM_REPO="$repo" AIPM_MODERNIZED=1 "$script_dir/issue-log.sh" "$issue_number" result "$result_file" --close
-cleanup_state_artifacts "$issue_number" "$state_dir"
+if [[ -n "$temp_main_worktree" && -d "$temp_main_worktree" ]]; then
+  git worktree remove "$temp_main_worktree" --force >/dev/null 2>&1 || true
+fi
 
 echo "[ok] PM close completed for issue #$issue_number"
+if [[ "${#warnings[@]}" -gt 0 ]]; then
+  printf 'warning=%s\n' "${warnings[@]}"
+fi

--- a/templates/aipm-ops/scripts/pm-modernize.sh
+++ b/templates/aipm-ops/scripts/pm-modernize.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  ./scripts/pm-modernize.sh --issue <issue-number> [--result-file <path>]
+  ./scripts/pm-modernize.sh --issue <issue-number> [--result-file <path>] [--yes]
 
 Examples:
   ./scripts/pm-modernize.sh --issue 218 --result-file docs/results/result-218.md
@@ -14,6 +14,7 @@ USAGE
 
 issue_number=""
 result_file=""
+yes_mode=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,6 +35,10 @@ while [[ $# -gt 0 ]]; do
       fi
       result_file="$2"
       shift 2
+      ;;
+    --yes)
+      yes_mode=1
+      shift
       ;;
     -h|--help)
       usage
@@ -83,7 +88,9 @@ cat <<'CHECKLIST'
 - Worktree cleanup and main integration status verified
 CHECKLIST
 
-if [[ -t 0 ]]; then
+if [[ "$yes_mode" -eq 1 ]]; then
+  :
+elif [[ -t 0 ]]; then
   echo "[confirm] If modernization is complete, type: MODERNIZED"
   printf "> "
   read -r ack
@@ -92,8 +99,8 @@ if [[ -t 0 ]]; then
     exit 1
   fi
 elif [[ "${AIPM_MODERNIZED:-0}" != "1" ]]; then
-  echo "error: non-interactive modernization requires AIPM_MODERNIZED=1." >&2
-  echo "hint: rerun in TTY or set AIPM_MODERNIZED=1 for automation." >&2
+  echo "error: non-interactive modernization requires explicit confirmation." >&2
+  echo "hint: rerun with --yes or set AIPM_MODERNIZED=1 for automation." >&2
   exit 1
 fi
 

--- a/templates/aipm-ops/scripts/pm-start.sh
+++ b/templates/aipm-ops/scripts/pm-start.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  ./scripts/pm-start.sh --title "<title>" [--body "<text>" | --body-file <path>] [--label <name>]... [--repo <owner/repo>] [--start-file <path>] [--plan-file <path>] [--progress-file <path>] [--branch <name>] [--worktree <path>] [--base <branch>] [--no-worktree] [--dry-run]
+  ./scripts/pm-start.sh --title "<title>" [--body "<text>" | --body-file <path>] [--label <name>]... [--repo <owner/repo>] [--start-file <path>] [--plan-file <path>] [--progress-file <path>] [--branch <name>] [--worktree <path>] [--base <branch>] [--no-worktree] [--budget-mode <warn|enforce|off>] [--budget-threshold <n>] [--force-budget] [--dry-run]
 
 Description:
   Standardized MODE 1 start flow for [pm] <title>.
@@ -18,6 +18,8 @@ Examples:
   ./scripts/pm-start.sh --title "[Task] Normalize PM mode docs" --label area:aipm --body "Goal and done criteria"
   ./scripts/pm-start.sh --title "[Feature] Add PM start wrapper" --start-file docs/start.md --plan-file docs/plan.md --progress-file docs/progress.md
   ./scripts/pm-start.sh --title "[Bug] Fix release note parser" --no-worktree
+  ./scripts/pm-start.sh --title "[Feature] Full pipeline automation" --budget-mode enforce
+  ./scripts/pm-start.sh --title "[Task] Full pipeline automation" --budget-mode enforce --force-budget
 USAGE
 }
 
@@ -37,6 +39,7 @@ infer_branch_type_from_title() {
   value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
   case "$value" in
     "[bug]"*) echo "fix" ;;
+    "[task]"*|"[test]"*) echo "task" ;;
     "[docs]"*) echo "docs" ;;
     "[chore]"*) echo "chore" ;;
     "[refactor]"*) echo "refactor" ;;
@@ -54,35 +57,63 @@ normalize_path() {
   fi
 }
 
-write_pm_state() {
-  local state_dir="$1"
-  local issue_number_val="$2"
-  local issue_key_val="$3"
-  local branch_val="$4"
-  local worktree_val="$5"
-  local create_worktree_val="$6"
-  local base_branch_val="$7"
-  local repo_root_val="$8"
-  local repo_val="$9"
-  local timestamp
+compute_scope_score() {
+  local text="$1"
+  local score=0
+  local chars=${#text}
 
-  mkdir -p "$state_dir"
-  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  if [[ "$chars" -ge 1200 ]]; then
+    score=$((score + 3))
+  elif [[ "$chars" -ge 700 ]]; then
+    score=$((score + 2))
+  elif [[ "$chars" -ge 350 ]]; then
+    score=$((score + 1))
+  fi
 
-  cat > "${state_dir}/pm-issue-${issue_number_val}.env" <<EOF
-# Managed by AIPM PM Start
-issue_number=${issue_number_val}
-issue_key=${issue_key_val}
-branch=${branch_val}
-worktree_path=${worktree_val}
-create_worktree=${create_worktree_val}
-base_branch=${base_branch_val}
-repo_root=${repo_root_val}
-repo=${repo_val}
-created_at=${timestamp}
-EOF
+  if printf '%s' "$text" | grep -Eqi '\b(parallel|pipeline|orchestr|multi[- ]?phase|end[- ]to[- ]end|full)\b'; then
+    score=$((score + 3))
+  fi
+  if printf '%s' "$text" | grep -Eqi '(병렬|파이프라인|오케스트|멀티|전 단계|전체 실행|엔드투엔드|풀런)'; then
+    score=$((score + 2))
+  fi
+  if printf '%s' "$text" | grep -Eqi '\b(phase|stage|agent|subagent|sub-agent|swarm)\b'; then
+    score=$((score + 2))
+  fi
+  if printf '%s' "$text" | grep -Eqi '(phase|stage|에이전트|서브에이전트|스웜)'; then
+    score=$((score + 1))
+  fi
 
-  cp "${state_dir}/pm-issue-${issue_number_val}.env" "${state_dir}/pm-active.env"
+  printf '%s' "$score"
+}
+
+run_budget_preflight() {
+  local title_val="$1"
+  local body_val="$2"
+  local mode_val="$3"
+  local threshold_val="$4"
+  local force_val="$5"
+  local combined=""
+  local scope_score=0
+
+  if [[ "$mode_val" == "off" ]]; then
+    return 0
+  fi
+
+  combined="$title_val"$'\n'"$body_val"
+  scope_score="$(compute_scope_score "$combined")"
+
+  if [[ "$scope_score" -lt "$threshold_val" ]]; then
+    return 0
+  fi
+
+  echo "[budget] scope-score=$scope_score (threshold=$threshold_val, mode=$mode_val)"
+  echo "[budget] large-scope work detected. Prefer a split session or explicit checkpointing."
+
+  if [[ "$mode_val" == "enforce" && "$force_val" -ne 1 ]]; then
+    echo "error: budget preflight blocked this start request." >&2
+    echo "hint: reduce scope or bypass explicitly with --force-budget." >&2
+    exit 2
+  fi
 }
 
 resolve_start_point() {
@@ -137,6 +168,9 @@ base_branch="${AIPM_PM_BASE_BRANCH:-main}"
 start_file=""
 plan_file=""
 progress_file=""
+budget_mode="${AIPM_PM_BUDGET_MODE:-warn}"
+budget_threshold="${AIPM_PM_BUDGET_THRESHOLD:-7}"
+force_budget=0
 labels=()
 tmp_files=()
 
@@ -213,6 +247,20 @@ while [[ $# -gt 0 ]]; do
       create_worktree=0
       shift
       ;;
+    --budget-mode)
+      [[ $# -lt 2 ]] && { echo "error: --budget-mode requires a value" >&2; exit 1; }
+      budget_mode="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
+      shift 2
+      ;;
+    --budget-threshold)
+      [[ $# -lt 2 ]] && { echo "error: --budget-threshold requires a value" >&2; exit 1; }
+      budget_threshold="$2"
+      shift 2
+      ;;
+    --force-budget)
+      force_budget=1
+      shift
+      ;;
     --dry-run)
       dry_run=1
       shift
@@ -250,6 +298,19 @@ if [[ -n "$body_file" && "$body_file" != "-" && ! -f "$body_file" ]]; then
   exit 1
 fi
 
+case "$budget_mode" in
+  warn|enforce|off) ;;
+  *)
+    echo "error: --budget-mode must be one of: warn, enforce, off" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! "$budget_threshold" =~ ^[0-9]+$ ]] || [[ "$budget_threshold" -lt 1 ]]; then
+  echo "error: --budget-threshold must be a positive integer" >&2
+  exit 1
+fi
+
 for phase_file in "$start_file" "$plan_file" "$progress_file"; do
   if [[ -n "$phase_file" && "$phase_file" != "-" && ! -f "$phase_file" ]]; then
     echo "error: phase file not found: $phase_file" >&2
@@ -261,6 +322,21 @@ repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$repo_root"
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pm-state.sh
+source "$script_dir/pm-state.sh"
+
+preflight_body=""
+if [[ -n "$body" ]]; then
+  preflight_body="$body"
+elif [[ -n "$body_file" ]]; then
+  if [[ "$body_file" == "-" ]]; then
+    preflight_body=""
+  else
+    preflight_body="$(cat "$body_file")"
+  fi
+fi
+
+run_budget_preflight "$title" "$preflight_body" "$budget_mode" "$budget_threshold" "$force_budget"
 
 create_cmd=("$script_dir/issue-create.sh" --title "$title")
 if [[ -n "$body" ]]; then
@@ -270,8 +346,11 @@ if [[ -n "$body_file" ]]; then
   create_cmd+=(--body-file "$body_file")
 fi
 for label in "${labels[@]-}"; do
-  create_cmd+=(--label "$label")
+  if [[ "$label" != status:* ]]; then
+    create_cmd+=(--label "$label")
+  fi
 done
+create_cmd+=(--label "status:in-progress")
 if [[ -n "$repo" ]]; then
   create_cmd+=(--repo "$repo")
 fi
@@ -307,7 +386,12 @@ if [[ -f ".aipm/ops.env" ]]; then
 fi
 issue_key_prefix="${ISSUE_KEY_PREFIX:-$issue_key_prefix}"
 issue_key="${issue_key_prefix}-${issue_number}"
-state_dir="${AIPM_STATE_DIR:-.aipm/state}"
+issue_repo="$repo"
+if [[ -z "$issue_repo" ]]; then
+  issue_repo="${issue_url#https://github.com/}"
+  issue_repo="${issue_repo%/issues/*}"
+fi
+pm_set_issue_status_label "$issue_repo" "$issue_number" "status:in-progress"
 
 create_default_phase_file() {
   local phase="$1"
@@ -319,6 +403,9 @@ create_default_phase_file() {
       cat > "$file" <<EOF
 - Scope:
   - $title
+- Intent Contract:
+  - Execution Mode: implement-now
+  - Deliverable Interpretation: rendered artifacts (PDF/ePub/build outputs) unless explicitly stated otherwise
 - Assumptions:
   - TBD
 - Done Criteria:
@@ -411,13 +498,27 @@ if [[ "$create_worktree" -eq 1 ]]; then
   fi
 fi
 
-write_pm_state "$state_dir" "$issue_number" "$issue_key" "${branch_name:-}" "${worktree_path:-}" "$create_worktree" "$base_branch" "$repo_root" "${repo:-}"
+result_file="$(pm_default_result_file "$issue_number" "$title")"
+started_at="$(pm_iso_now)"
+pm_write_active_issue_state \
+  "$issue_number" \
+  "$title" \
+  "$branch_name" \
+  "$worktree_path" \
+  "$issue_repo" \
+  "${start_file:-}" \
+  "${plan_file:-}" \
+  "${progress_file:-}" \
+  "$result_file" \
+  "in_progress" \
+  "$started_at"
 
 echo "[ok] PM start completed for issue #$issue_number"
 echo "issue_url=$issue_url"
+echo "active_state=$(pm_active_issue_file)"
+echo "result_file=$result_file"
 if [[ "$create_worktree" -eq 1 ]]; then
   echo "branch=$branch_name"
   echo "worktree_path=$worktree_path"
   echo "next=cd \"$worktree_path\""
 fi
-echo "state_file=${state_dir}/pm-issue-${issue_number}.env"

--- a/templates/aipm-ops/scripts/pm-state.sh
+++ b/templates/aipm-ops/scripts/pm-state.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Shared PM lifecycle state helpers.
+set -euo pipefail
+
+pm_state_dir() {
+  printf '%s' "${AIPM_STATE_DIR:-.aipm/state}"
+}
+
+pm_active_issue_file() {
+  printf '%s/active-issue.json' "$(pm_state_dir)"
+}
+
+pm_last_active_issue_file() {
+  printf '%s/active-issue.last.json' "$(pm_state_dir)"
+}
+
+pm_iso_now() {
+  python3 - <<'PY'
+import datetime as dt
+print(dt.datetime.now(dt.timezone.utc).isoformat())
+PY
+}
+
+pm_slugify_title() {
+  local value="$1"
+  value="$(printf '%s' "$value" | sed -E 's/^[[:space:]]*\[[^]]+\][[:space:]]*//')"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+  value="$(printf '%s' "$value" | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+  if [[ -z "$value" ]]; then
+    value="work"
+  fi
+  printf '%s' "$value"
+}
+
+pm_infer_type_label_from_title() {
+  local value
+  value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
+    "[epic]"*) echo "type:epic" ;;
+    "[feature]"*) echo "type:feature" ;;
+    "[story]"*) echo "type:story" ;;
+    "[task]"*|"[test]"*) echo "type:task" ;;
+    "[bug]"*) echo "type:bug" ;;
+    "[chore]"*) echo "type:chore" ;;
+    "[docs]"*) echo "type:docs" ;;
+    "[refactor]"*) echo "type:refactor" ;;
+    "[prd]"*) echo "type:prd" ;;
+    "[plan]"*) echo "type:plan" ;;
+    "[result]"*) echo "type:result" ;;
+    *) echo "type:task" ;;
+  esac
+}
+
+pm_default_result_file() {
+  local issue_number="$1"
+  local title="$2"
+  printf 'docs/results/result-%s-%s.md' "$issue_number" "$(pm_slugify_title "$title")"
+}
+
+pm_write_active_issue_state() {
+  local issue_number="$1"
+  local title="$2"
+  local branch_name="$3"
+  local worktree_path="$4"
+  local repo="$5"
+  local start_file="$6"
+  local plan_file="$7"
+  local progress_file="$8"
+  local result_file="$9"
+  local status="${10}"
+  local started_at="${11}"
+  local active_file
+  active_file="$(pm_active_issue_file)"
+  mkdir -p "$(pm_state_dir)"
+  python3 - "$active_file" "$issue_number" "$title" "$branch_name" "$worktree_path" "$repo" "$start_file" "$plan_file" "$progress_file" "$result_file" "$status" "$started_at" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+(
+    active_file,
+    issue_number,
+    title,
+    branch_name,
+    worktree_path,
+    repo,
+    start_file,
+    plan_file,
+    progress_file,
+    result_file,
+    status,
+    started_at,
+) = sys.argv[1:13]
+
+payload = {
+    "issue": int(issue_number),
+    "title": title,
+    "branch": branch_name,
+    "worktree": worktree_path,
+    "repo": repo,
+    "started_at": started_at,
+    "updated_at": datetime.now(timezone.utc).isoformat(),
+    "start_file": start_file,
+    "plan_file": plan_file,
+    "progress_file": progress_file,
+    "result_file": result_file,
+    "status": status,
+}
+path = Path(active_file)
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+pm_update_active_issue_status() {
+  local next_status="$1"
+  local active_file
+  active_file="$(pm_active_issue_file)"
+  [[ -f "$active_file" ]] || return 0
+  python3 - "$active_file" "$next_status" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+path = Path(sys.argv[1])
+status = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["status"] = status
+payload["updated_at"] = datetime.now(timezone.utc).isoformat()
+path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+pm_read_active_field() {
+  local field="$1"
+  local active_file
+  active_file="$(pm_active_issue_file)"
+  if [[ ! -f "$active_file" ]]; then
+    return 1
+  fi
+  python3 - "$active_file" "$field" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+field = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+value = payload.get(field, "")
+if isinstance(value, (dict, list)):
+    import json as _json
+    print(_json.dumps(value, ensure_ascii=False))
+else:
+    print(value)
+PY
+}
+
+pm_read_active_json() {
+  local active_file
+  active_file="$(pm_active_issue_file)"
+  [[ -f "$active_file" ]] || return 1
+  cat "$active_file"
+}
+
+pm_active_issue_matches() {
+  local issue_number="$1"
+  local current_issue=""
+  current_issue="$(pm_read_active_field issue 2>/dev/null || true)"
+  [[ -n "$current_issue" && "$current_issue" == "$issue_number" ]]
+}
+
+pm_archive_active_issue() {
+  local active_file last_file
+  active_file="$(pm_active_issue_file)"
+  last_file="$(pm_last_active_issue_file)"
+  if [[ -f "$active_file" ]]; then
+    mkdir -p "$(pm_state_dir)"
+    mv "$active_file" "$last_file"
+  fi
+}
+
+pm_clear_active_issue() {
+  local active_file
+  active_file="$(pm_active_issue_file)"
+  [[ -f "$active_file" ]] || return 0
+  rm -f "$active_file"
+}
+
+pm_set_issue_status_label() {
+  local repo="$1"
+  local issue_number="$2"
+  local target_status="$3"
+  gh issue edit "$issue_number" --repo "$repo" \
+    --add-label "$target_status" \
+    --remove-label "status:todo" \
+    --remove-label "status:in-progress" \
+    --remove-label "status:blocked" \
+    --remove-label "status:review" \
+    --remove-label "status:done" \
+    --remove-label "status:wont-fix" \
+    --remove-label "status:duplicate" >/dev/null
+}
+
+pm_add_type_label_if_missing() {
+  local repo="$1"
+  local issue_number="$2"
+  local title="$3"
+  local labels_json type_count inferred_type
+  labels_json="$(gh issue view "$issue_number" --repo "$repo" --json labels)"
+  type_count="$(jq '[.labels[].name | ascii_downcase | select(startswith("type:"))] | length' <<<"$labels_json")"
+  if [[ "$type_count" -eq 0 ]]; then
+    inferred_type="$(pm_infer_type_label_from_title "$title")"
+    gh issue edit "$issue_number" --repo "$repo" --add-label "$inferred_type" >/dev/null
+  fi
+}
+
+pm_find_recent_issue_from_comments() {
+  local repo="$1"
+  local limit="${2:-30}"
+  local issues_json issue_number view_json
+  issues_json="$(gh issue list --repo "$repo" --state open --limit "$limit" --json number,title,updatedAt,url \
+    | jq 'sort_by(.updatedAt) | reverse')"
+  while IFS= read -r issue_number; do
+    [[ -n "$issue_number" ]] || continue
+    view_json="$(gh issue view "$issue_number" --repo "$repo" --json number,title,state,url,labels,comments)"
+    if jq -e '[.comments[].body | select(test("^### (START|PLAN|PROGRESS) \\| "; "m"))] | length > 0' <<<"$view_json" >/dev/null; then
+      printf '%s\n' "$view_json"
+      return 0
+    fi
+  done < <(jq -r '.[].number' <<<"$issues_json")
+  return 1
+}
+
+pm_find_worktree_for_branch() {
+  local target_branch="$1"
+  local current_path=""
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        current_path="${line#worktree }"
+        ;;
+      branch\ refs/heads/*)
+        local branch_name="${line#branch refs/heads/}"
+        if [[ "$branch_name" == "$target_branch" ]]; then
+          printf '%s' "$current_path"
+          return 0
+        fi
+        ;;
+      "")
+        current_path=""
+        ;;
+    esac
+  done < <(git worktree list --porcelain)
+  return 1
+}
+
+pm_abs_path() {
+  python3 - "$1" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).resolve())
+PY
+}
+
+pm_resolve_path_in_worktree() {
+  local worktree_path="$1"
+  local repo_relative_path="$2"
+  python3 - "$worktree_path" "$repo_relative_path" <<'PY'
+from pathlib import Path
+import sys
+
+worktree = Path(sys.argv[1]).resolve()
+relative = Path(sys.argv[2])
+print((worktree / relative).resolve())
+PY
+}

--- a/templates/aipm-ops/scripts/pm-sync.sh
+++ b/templates/aipm-ops/scripts/pm-sync.sh
@@ -5,97 +5,30 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  ./scripts/pm-sync.sh [--issue <issue-number>] [--state-dir <path>] [--worktree-root <path>] [--strict]
+  ./scripts/pm-sync.sh [--repo <owner/repo>] [--issue <n>] [--json]
 
 Description:
-  Audits PM issue state files against actual git worktree registrations.
-  - checks issue->branch->worktree mapping recorded by pm-start
-  - detects mapping mismatches and missing worktrees
-  - detects orphaned managed worktrees under .aipm/worktrees
-
-Options:
-  --issue <n>           Check only one issue
-  --state-dir <path>    State directory (default: .aipm/state)
-  --worktree-root <p>   Managed worktree root (default: .aipm/worktrees)
-  --strict              Exit 2 when violations are found
-
-Examples:
-  ./scripts/pm-sync.sh
-  ./scripts/pm-sync.sh --issue 218
-  ./scripts/pm-sync.sh --strict
+  Reports PM lifecycle sync state for the active issue or the most recent open issue
+  that already has START/PLAN/PROGRESS comments.
 USAGE
 }
 
-get_state_value() {
-  local file="$1"
-  local key="$2"
-  awk -F= -v target="$key" '$1 == target { print substr($0, index($0, "=") + 1); exit }' "$file"
-}
-
-find_worktree_for_branch() {
-  local target_branch="$1"
-  local current_path=""
-  while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        current_path="${line#worktree }"
-        ;;
-      branch\ refs/heads/*)
-        local branch_name="${line#branch refs/heads/}"
-        if [[ "$branch_name" == "$target_branch" ]]; then
-          printf '%s' "$current_path"
-          return 0
-        fi
-        ;;
-      "")
-        current_path=""
-        ;;
-    esac
-  done < <(git worktree list --porcelain)
-  return 1
-}
-
-normalize_path() {
-  local value="$1"
-  local root="$2"
-  if [[ "$value" = /* ]]; then
-    printf '%s' "$value"
-  else
-    printf '%s/%s' "$root" "$value"
-  fi
-}
-
-add_violation() {
-  local code="$1"
-  local message="$2"
-  violation_count=$((violation_count + 1))
-  printf '%s|%s\n' "$code" "$message" >>"$violations_file"
-}
-
-issue_filter=""
-strict=0
-state_dir=""
-worktree_root=""
+repo=""
+issue_number=""
+json_output=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
     --issue)
-      [[ $# -lt 2 ]] && { echo "error: --issue requires a value" >&2; exit 1; }
-      issue_filter="$2"
+      issue_number="$2"
       shift 2
       ;;
-    --state-dir)
-      [[ $# -lt 2 ]] && { echo "error: --state-dir requires a value" >&2; exit 1; }
-      state_dir="$2"
-      shift 2
-      ;;
-    --worktree-root)
-      [[ $# -lt 2 ]] && { echo "error: --worktree-root requires a value" >&2; exit 1; }
-      worktree_root="$2"
-      shift 2
-      ;;
-    --strict)
-      strict=1
+    --json)
+      json_output=1
       shift
       ;;
     -h|--help)
@@ -110,124 +43,212 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -n "$issue_filter" && ! "$issue_filter" =~ ^[0-9]+$ ]]; then
-  echo "error: --issue must be numeric: $issue_filter" >&2
-  exit 1
-fi
-
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$repo_root"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pm-state.sh
+source "$script_dir/pm-state.sh"
 
-state_dir="${state_dir:-${AIPM_STATE_DIR:-.aipm/state}}"
-worktree_root="${worktree_root:-${AIPM_WORKTREE_ROOT:-$repo_root/.aipm/worktrees}}"
-worktree_root="$(normalize_path "$worktree_root" "$repo_root")"
+if [[ -z "$repo" ]]; then
+  repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+fi
 
-violations_file="$(mktemp)"
-tracked_paths_file="$(mktemp)"
-trap 'rm -f "$violations_file" "$tracked_paths_file"' EXIT
+active_json=""
+issue_json=""
+source_mode="none"
 
-violation_count=0
-state_count=0
-checked_count=0
+if [[ -n "$issue_number" ]]; then
+  issue_json="$(gh issue view "$issue_number" --repo "$repo" --json number,title,state,url,labels,comments)"
+  source_mode="explicit"
+elif active_json="$(pm_read_active_json 2>/dev/null || true)"; [[ -n "$active_json" ]]; then
+  issue_number="$(jq -r '.issue' <<<"$active_json")"
+  issue_json="$(gh issue view "$issue_number" --repo "$repo" --json number,title,state,url,labels,comments)"
+  source_mode="active"
+else
+  issue_json="$(pm_find_recent_issue_from_comments "$repo" 30 || true)"
+  if [[ -n "$issue_json" ]]; then
+    issue_number="$(jq -r '.number' <<<"$issue_json")"
+    source_mode="discovered"
+  fi
+fi
 
-shopt -s nullglob
-state_files=("$state_dir"/pm-issue-*.env)
-shopt -u nullglob
-
-if [[ "${#state_files[@]}" -eq 0 ]]; then
-  echo "repo_root=$repo_root"
-  echo "state_dir=$state_dir"
-  echo "worktree_root=$worktree_root"
-  echo "state_files=0"
-  echo "issues_checked=0"
-  echo "violations=0"
-  echo "details=none"
+if [[ -z "$issue_json" ]]; then
+  if [[ "$json_output" -eq 1 ]]; then
+    jq -n --arg repo "$repo" '{
+      repo: $repo,
+      source: "none",
+      state: "attention",
+      next_action: "Start with [pm] <title>.",
+      checks: { active_issue: false }
+    }'
+  else
+    echo "state=attention"
+    echo "source=none"
+    echo "next_action=Start with [pm] <title>."
+  fi
   exit 0
 fi
 
-for state_file in "${state_files[@]}"; do
-  state_count=$((state_count + 1))
+issue_state="$(jq -r '.state | ascii_downcase' <<<"$issue_json")"
+title="$(jq -r '.title' <<<"$issue_json")"
+issue_url="$(jq -r '.url' <<<"$issue_json")"
+status_labels="$(jq -r '[.labels[].name | ascii_downcase | select(startswith("status:"))] | join(",")' <<<"$issue_json")"
+type_labels="$(jq -r '[.labels[].name | ascii_downcase | select(startswith("type:"))] | join(",")' <<<"$issue_json")"
+status_count="$(jq '[.labels[].name | ascii_downcase | select(startswith("status:"))] | length' <<<"$issue_json")"
+type_count="$(jq '[.labels[].name | ascii_downcase | select(startswith("type:"))] | length' <<<"$issue_json")"
+has_start="$(jq '[.comments[].body | select(test("^### START \\| "; "m"))] | length > 0' <<<"$issue_json")"
+has_plan="$(jq '[.comments[].body | select(test("^### PLAN \\| "; "m"))] | length > 0' <<<"$issue_json")"
+has_progress="$(jq '[.comments[].body | select(test("^### PROGRESS \\| "; "m"))] | length > 0' <<<"$issue_json")"
 
-  state_issue="$(get_state_value "$state_file" "issue_number")"
-  if [[ -z "$state_issue" ]]; then
-    state_issue="$(basename "$state_file" | sed -E 's/^pm-issue-([0-9]+)\.env$/\1/')"
-  fi
-
-  if [[ -n "$issue_filter" && "$state_issue" != "$issue_filter" ]]; then
-    continue
-  fi
-
-  checked_count=$((checked_count + 1))
-
-  state_branch="$(get_state_value "$state_file" "branch")"
-  state_worktree="$(get_state_value "$state_file" "worktree_path")"
-  state_create_worktree="$(get_state_value "$state_file" "create_worktree")"
-
-  if [[ "${state_create_worktree:-0}" != "1" ]]; then
-    continue
-  fi
-
-  if [[ -z "$state_branch" ]]; then
-    add_violation "missing_branch" "issue #$state_issue has empty branch in state ($state_file)"
-    continue
-  fi
-
-  if [[ -z "$state_worktree" ]]; then
-    add_violation "missing_worktree_path" "issue #$state_issue has empty worktree_path in state ($state_file)"
-    continue
-  fi
-
-  registered_worktree="$(find_worktree_for_branch "$state_branch" || true)"
-  if [[ -z "$registered_worktree" ]]; then
-    add_violation "branch_without_worktree" "issue #$state_issue branch '$state_branch' has no registered worktree"
-    continue
-  fi
-
-  printf '%s\n' "$registered_worktree" >>"$tracked_paths_file"
-
-  if [[ "$registered_worktree" != "$state_worktree" ]]; then
-    add_violation "state_path_mismatch" "issue #$state_issue branch '$state_branch' state='$state_worktree' actual='$registered_worktree'"
-  fi
-
-done
-
-if [[ -z "$issue_filter" ]]; then
-  current_path=""
-  while IFS= read -r line; do
-    case "$line" in
-      worktree\ *)
-        current_path="${line#worktree }"
-        ;;
-      "")
-        if [[ -n "$current_path" && "$current_path" == "$worktree_root"/* ]]; then
-          if ! grep -Fxq "$current_path" "$tracked_paths_file"; then
-            add_violation "orphan_worktree" "managed worktree without active PM state: $current_path"
-          fi
-        fi
-        current_path=""
-        ;;
-    esac
-  done < <(git worktree list --porcelain)
+branch_name=""
+worktree_path=""
+result_file=""
+active_present=0
+if [[ -n "$active_json" ]]; then
+  active_present=1
+  branch_name="$(jq -r '.branch // ""' <<<"$active_json")"
+  worktree_path="$(jq -r '.worktree // ""' <<<"$active_json")"
+  result_file="$(jq -r '.result_file // ""' <<<"$active_json")"
+fi
+if [[ -z "$result_file" ]]; then
+  result_file="$(pm_default_result_file "$issue_number" "$title")"
 fi
 
-echo "repo_root=$repo_root"
-echo "state_dir=$state_dir"
-echo "worktree_root=$worktree_root"
-echo "state_files=$state_count"
-echo "issues_checked=$checked_count"
-echo "violations=$violation_count"
+branch_exists=0
+worktree_exists=0
+result_exists=0
+merged_pr=0
+modernized=0
+if [[ -n "$branch_name" ]] && git show-ref --verify --quiet "refs/heads/$branch_name"; then
+  branch_exists=1
+fi
+if [[ -n "$worktree_path" ]] && [[ -d "$worktree_path" ]]; then
+  worktree_exists=1
+fi
+if [[ -f "$result_file" ]]; then
+  result_exists=1
+fi
+if gh pr list --repo "$repo" --state merged --search "#$issue_number" --limit 30 --json number | jq -e 'length > 0' >/dev/null; then
+  merged_pr=1
+fi
+if [[ -f "$(pm_state_dir)/modernized-${issue_number}.flag" ]]; then
+  modernized=1
+fi
 
-if [[ "$violation_count" -gt 0 ]]; then
-  while IFS= read -r line; do
-    [[ -z "$line" ]] && continue
-    code="${line%%|*}"
-    message="${line#*|}"
-    echo "- [$code] $message"
-  done <"$violations_file"
+summary_state="healthy"
+next_action="Continue implementation."
+blockers=()
+
+if [[ "$issue_state" != "open" ]]; then
+  summary_state="blocked"
+  blockers+=("issue_not_open")
+  next_action="Clear stale active issue state or start a new PM task."
+fi
+if [[ "$status_count" -ne 1 || "$type_count" -ne 1 ]]; then
+  if [[ "$summary_state" == "healthy" ]]; then
+    summary_state="attention"
+  fi
+  blockers+=("label_integrity")
+  next_action="Run ./scripts/check-pm-integrity.sh --fix-active or repair labels."
+fi
+if [[ "$has_start" != "true" || "$has_plan" != "true" || "$has_progress" != "true" ]]; then
+  if [[ "$summary_state" == "healthy" ]]; then
+    summary_state="attention"
+  fi
+  blockers+=("phase_logs_missing")
+  next_action="Post missing START/PLAN/PROGRESS logs."
+fi
+if [[ "$active_present" -eq 1 && ( "$branch_exists" -ne 1 || "$worktree_exists" -ne 1 ) ]]; then
+  summary_state="blocked"
+  blockers+=("branch_or_worktree_missing")
+  next_action="Restore the tracked worktree/branch or refresh active state."
+fi
+if [[ "$result_exists" -eq 1 && "$merged_pr" -ne 1 ]]; then
+  if [[ "$summary_state" == "healthy" ]]; then
+    summary_state="attention"
+  fi
+  blockers+=("pr_not_merged")
+  next_action="Run [pm] close to land the branch and close the issue."
+fi
+if [[ "$result_exists" -eq 1 && "$merged_pr" -eq 1 && "$modernized" -ne 1 ]]; then
+  if [[ "$summary_state" == "healthy" ]]; then
+    summary_state="attention"
+  fi
+  blockers+=("ready_to_close")
+  next_action="Run [pm] done or ./scripts/pm-close.sh --from-active --yes."
+fi
+
+if [[ "$json_output" -eq 1 ]]; then
+  jq -n \
+    --arg repo "$repo" \
+    --arg source "$source_mode" \
+    --arg state "$summary_state" \
+    --arg next_action "$next_action" \
+    --argjson issue "$issue_number" \
+    --arg title "$title" \
+    --arg url "$issue_url" \
+    --arg issue_state "$issue_state" \
+    --arg status_labels "$status_labels" \
+    --arg type_labels "$type_labels" \
+    --arg branch "$branch_name" \
+    --arg worktree "$worktree_path" \
+    --arg result_file "$result_file" \
+    --argjson active_issue "$( [[ "$active_present" -eq 1 ]] && echo true || echo false )" \
+    --argjson branch_exists "$( [[ "$branch_exists" -eq 1 ]] && echo true || echo false )" \
+    --argjson worktree_exists "$( [[ "$worktree_exists" -eq 1 ]] && echo true || echo false )" \
+    --argjson result_exists "$( [[ "$result_exists" -eq 1 ]] && echo true || echo false )" \
+    --argjson merged_pr "$( [[ "$merged_pr" -eq 1 ]] && echo true || echo false )" \
+    --argjson modernized "$( [[ "$modernized" -eq 1 ]] && echo true || echo false )" \
+    --argjson has_start "$has_start" \
+    --argjson has_plan "$has_plan" \
+    --argjson has_progress "$has_progress" \
+    --argjson blockers "$(printf '%s\n' "${blockers[@]-}" | jq -R -s 'split("\n") | map(select(length > 0))')" \
+    '{
+      repo: $repo,
+      source: $source,
+      state: $state,
+      next_action: $next_action,
+      issue: {
+        number: $issue,
+        title: $title,
+        state: $issue_state,
+        url: $url
+      },
+      checks: {
+        active_issue: $active_issue,
+        status_labels: $status_labels,
+        type_labels: $type_labels,
+        has_start: $has_start,
+        has_plan: $has_plan,
+        has_progress: $has_progress,
+        branch: $branch,
+        branch_exists: $branch_exists,
+        worktree: $worktree,
+        worktree_exists: $worktree_exists,
+        result_file: $result_file,
+        result_exists: $result_exists,
+        merged_pr: $merged_pr,
+        modernized: $modernized
+      },
+      blockers: $blockers
+    }'
 else
-  echo "details=none"
-fi
-
-if [[ "$strict" -eq 1 && "$violation_count" -gt 0 ]]; then
-  exit 2
+  echo "state=$summary_state"
+  echo "source=$source_mode"
+  echo "issue=$issue_number"
+  echo "title=$title"
+  echo "next_action=$next_action"
+  echo "checks:"
+  echo "- status_labels=${status_labels:-<none>}"
+  echo "- type_labels=${type_labels:-<none>}"
+  echo "- start=$has_start plan=$has_plan progress=$has_progress"
+  echo "- branch=${branch_name:-<none>} exists=$branch_exists"
+  echo "- worktree=${worktree_path:-<none>} exists=$worktree_exists"
+  echo "- result_file=$result_file exists=$result_exists"
+  echo "- merged_pr=$merged_pr modernized=$modernized"
+  if [[ "${#blockers[@]}" -gt 0 ]]; then
+    echo "blockers=${blockers[*]}"
+  else
+    echo "blockers=none"
+  fi
 fi

--- a/tests/e2e/test_pm_issue_ops.py
+++ b/tests/e2e/test_pm_issue_ops.py
@@ -1,0 +1,622 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REQUIRED_SCRIPTS = [
+    "check-pm-integrity.sh",
+    "issue-create.sh",
+    "issue-log.sh",
+    "pm-close.sh",
+    "pm-modernize.sh",
+    "pm-start.sh",
+    "pm-state.sh",
+    "pm-sync.sh",
+    "setup-labels.sh",
+]
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _write_fake_gh(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env python3
+from __future__ import annotations
+import json, os, subprocess, sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+state_path = Path(os.environ["FAKE_GH_STATE"])
+
+def load():
+    return json.loads(state_path.read_text(encoding="utf-8"))
+
+def save(data):
+    state_path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+
+def now():
+    return datetime.now(timezone.utc).isoformat()
+
+def arg_value(args, flag, default=""):
+    if flag not in args:
+        return default
+    idx = args.index(flag)
+    return args[idx + 1]
+
+def collect_multi(args, flag):
+    values = []
+    idx = 0
+    while idx < len(args):
+        if args[idx] == flag:
+            values.append(args[idx + 1])
+            idx += 2
+        else:
+            idx += 1
+    return values
+
+def apply_jq(payload, expr):
+    proc = subprocess.run(
+        ["jq", "-r", expr],
+        input=json.dumps(payload, ensure_ascii=False).encode(),
+        check=True,
+        capture_output=True,
+    )
+    sys.stdout.write(proc.stdout.decode())
+
+args = sys.argv[1:]
+if args[:2] == ["repo", "view"]:
+    data = load()
+    payload = {"nameWithOwner": data["repo"]}
+    if "--jq" in args:
+        apply_jq(payload, arg_value(args, "--jq"))
+    else:
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False))
+    raise SystemExit(0)
+
+if args[:2] == ["label", "list"]:
+    data = load()
+    payload = [{"name": name} for name in data.get("labels", [])]
+    if "--jq" in args:
+        apply_jq(payload, arg_value(args, "--jq"))
+    else:
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False))
+    raise SystemExit(0)
+
+if args[:2] == ["issue", "create"]:
+    data = load()
+    title = arg_value(args, "--title")
+    body = arg_value(args, "--body", "")
+    body_file = arg_value(args, "--body-file", "")
+    if body_file:
+      body = Path(body_file).read_text(encoding="utf-8")
+    labels = collect_multi(args, "--label")
+    number = int(data.get("next_issue", 1))
+    issue = {
+        "number": number,
+        "title": title,
+        "body": body,
+        "state": "OPEN",
+        "url": f"https://github.com/{data['repo']}/issues/{number}",
+        "labels": labels,
+        "comments": [],
+        "updatedAt": now(),
+    }
+    data.setdefault("issues", []).append(issue)
+    data["next_issue"] = number + 1
+    save(data)
+    print(issue["url"])
+    raise SystemExit(0)
+
+if args[:2] == ["issue", "list"]:
+    data = load()
+    state = arg_value(args, "--state", "open").lower()
+    issues = data.get("issues", [])
+    filtered = []
+    for issue in issues:
+        if state == "all" or issue["state"].lower() == state:
+            filtered.append(issue)
+    payload = []
+    for issue in filtered:
+        payload.append(
+            {
+                "number": issue["number"],
+                "title": issue["title"],
+                "state": issue["state"],
+                "url": issue["url"],
+                "updatedAt": issue.get("updatedAt", now()),
+                "labels": [{"name": label} for label in issue.get("labels", [])],
+            }
+        )
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False))
+    raise SystemExit(0)
+
+if args[:2] == ["issue", "view"]:
+    data = load()
+    issue_number = int(args[2])
+    issue = next(item for item in data.get("issues", []) if int(item["number"]) == issue_number)
+    payload = {
+        "number": issue["number"],
+        "title": issue["title"],
+        "body": issue.get("body", ""),
+        "state": issue["state"],
+        "url": issue["url"],
+        "labels": [{"name": label} for label in issue.get("labels", [])],
+        "comments": issue.get("comments", []),
+    }
+    if "--jq" in args:
+        apply_jq(payload, arg_value(args, "--jq"))
+    else:
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False))
+    raise SystemExit(0)
+
+if args[:2] == ["issue", "edit"]:
+    data = load()
+    issue_number = int(args[2])
+    issue = next(item for item in data.get("issues", []) if int(item["number"]) == issue_number)
+    add_labels = collect_multi(args, "--add-label")
+    remove_labels = collect_multi(args, "--remove-label")
+    labels = [label for label in issue.get("labels", []) if label not in remove_labels]
+    for label in add_labels:
+        if label not in labels:
+            labels.append(label)
+    issue["labels"] = labels
+    issue["updatedAt"] = now()
+    save(data)
+    raise SystemExit(0)
+
+if args[:2] == ["issue", "comment"]:
+    data = load()
+    issue_number = int(args[2])
+    issue = next(item for item in data.get("issues", []) if int(item["number"]) == issue_number)
+    body = arg_value(args, "--body")
+    issue.setdefault("comments", []).append({"body": body, "createdAt": now()})
+    issue["updatedAt"] = now()
+    save(data)
+    print(f"https://github.com/{data['repo']}/issues/{issue_number}#comment")
+    raise SystemExit(0)
+
+if args[:2] == ["issue", "close"]:
+    data = load()
+    issue_number = int(args[2])
+    issue = next(item for item in data.get("issues", []) if int(item["number"]) == issue_number)
+    issue["state"] = "CLOSED"
+    issue["updatedAt"] = now()
+    save(data)
+    print(f"Closed issue #{issue_number}")
+    raise SystemExit(0)
+
+if args[:2] == ["pr", "list"]:
+    data = load()
+    state = arg_value(args, "--state", "open").upper()
+    search = arg_value(args, "--search", "")
+    payload = []
+    for pr in data.get("prs", []):
+        if pr.get("state", "").upper() != state:
+            continue
+        haystack = f"{pr.get('title', '')}\\n{pr.get('body', '')}"
+        if search and search not in haystack:
+            continue
+        payload.append(pr)
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False))
+    raise SystemExit(0)
+
+if args[:2] == ["pr", "create"]:
+    data = load()
+    title = arg_value(args, "--title")
+    body = arg_value(args, "--body", "")
+    body_file = arg_value(args, "--body-file", "")
+    if body_file:
+        body = Path(body_file).read_text(encoding="utf-8")
+    number = int(data.get("next_pr", 1))
+    pr = {
+        "number": number,
+        "title": title,
+        "body": body,
+        "url": f"https://github.com/{data['repo']}/pull/{number}",
+        "mergedAt": None,
+        "state": "OPEN",
+    }
+    data.setdefault("prs", []).append(pr)
+    data["next_pr"] = number + 1
+    save(data)
+    print(pr["url"])
+    raise SystemExit(0)
+
+if args[:2] == ["pr", "merge"]:
+    data = load()
+    pr_number = int(args[2])
+    pr = next(item for item in data.get("prs", []) if int(item["number"]) == pr_number)
+    pr["state"] = "MERGED"
+    pr["mergedAt"] = now()
+    save(data)
+    print(f"Merged pull request #{pr_number}")
+    raise SystemExit(0)
+
+raise SystemExit(f"unsupported gh invocation: {' '.join(args)}")
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _make_repo(tmp_path: Path, gh_state: dict) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    scripts_dir = repo / "scripts"
+    scripts_dir.mkdir()
+    for rel in REQUIRED_SCRIPTS:
+        shutil.copy2(_repo_root() / "scripts" / rel, scripts_dir / rel)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_fake_gh(fake_bin / "gh")
+    state_path = tmp_path / "gh-state.json"
+    state_path.write_text(
+        json.dumps(gh_state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "pm@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "PM Bot"], cwd=repo, check=True)
+    aipm_dir = repo / ".aipm"
+    aipm_dir.mkdir()
+    (aipm_dir / "ops.env").write_text("ISSUE_KEY_PREFIX=PP\n", encoding="utf-8")
+    (repo / "README.md").write_text("test repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    remote = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=repo, check=True)
+    subprocess.run(["git", "push", "-u", "origin", "main"], cwd=repo, check=True, capture_output=True)
+    return repo, state_path
+
+
+def _run(repo: Path, state_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{state_path.parent / 'bin'}:{env['PATH']}"
+    env["FAKE_GH_STATE"] = str(state_path)
+    return subprocess.run(
+        list(args),
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_pm_start_writes_active_issue_state_and_in_progress_label(tmp_path: Path):
+    repo, state_path = _make_repo(
+        tmp_path,
+        {
+            "repo": "owner/repo",
+            "next_issue": 1,
+            "next_pr": 1,
+            "issues": [],
+            "prs": [],
+            "labels": ["type:task", "status:todo", "status:in-progress", "area:aipm"],
+        },
+    )
+
+    proc = _run(
+        repo,
+        state_path,
+        "bash",
+        "scripts/pm-start.sh",
+        "--title",
+        "[Task] Demo flow",
+        "--label",
+        "area:aipm",
+        "--body",
+        "scope",
+    )
+    assert proc.returncode == 0, proc.stderr
+    active = json.loads((repo / ".aipm/state/active-issue.json").read_text(encoding="utf-8"))
+    assert active["issue"] == 1
+    assert active["status"] == "in_progress"
+    assert active["branch"].startswith("task/PP-1-demo-flow")
+    assert active["result_file"] == "docs/results/result-1-demo-flow.md"
+
+    gh_state = json.loads(state_path.read_text(encoding="utf-8"))
+    issue = gh_state["issues"][0]
+    assert "status:in-progress" in issue["labels"]
+    assert "status:todo" not in issue["labels"]
+
+
+def test_pm_sync_discovers_recent_issue_without_active_state(tmp_path: Path):
+    repo, state_path = _make_repo(
+        tmp_path,
+        {
+            "repo": "owner/repo",
+            "next_issue": 2,
+            "next_pr": 1,
+            "issues": [
+                {
+                    "number": 1,
+                    "title": "[Task] Existing flow",
+                    "body": "body",
+                    "state": "OPEN",
+                    "url": "https://github.com/owner/repo/issues/1",
+                    "labels": ["type:task", "status:in-progress"],
+                    "updatedAt": "2026-03-06T00:00:00+00:00",
+                    "comments": [
+                        {"body": "### START | PP-1\nx", "createdAt": "2026-03-06T00:00:00+00:00"},
+                        {"body": "### PLAN | PP-1\nx", "createdAt": "2026-03-06T00:01:00+00:00"},
+                        {
+                            "body": "### PROGRESS | PP-1\nx",
+                            "createdAt": "2026-03-06T00:02:00+00:00",
+                        },
+                    ],
+                }
+            ],
+            "prs": [],
+            "labels": ["type:task", "status:in-progress"],
+        },
+    )
+
+    proc = _run(repo, state_path, "bash", "scripts/pm-sync.sh", "--json")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["source"] == "discovered"
+    assert payload["issue"]["number"] == 1
+    assert payload["state"] == "healthy"
+
+
+def test_pm_close_from_active_archives_state_and_marks_done(tmp_path: Path):
+    repo, state_path = _make_repo(
+        tmp_path,
+        {
+            "repo": "owner/repo",
+            "next_issue": 2,
+            "next_pr": 11,
+            "issues": [
+                {
+                    "number": 1,
+                    "title": "[Task] Close flow",
+                    "body": "body",
+                    "state": "OPEN",
+                    "url": "https://github.com/owner/repo/issues/1",
+                    "labels": ["type:task", "status:in-progress"],
+                    "updatedAt": "2026-03-06T00:00:00+00:00",
+                    "comments": [],
+                }
+            ],
+            "prs": [
+                {
+                    "number": 10,
+                    "title": "PR",
+                    "body": "Closes #1",
+                    "url": "https://github.com/owner/repo/pull/10",
+                    "mergedAt": "2026-03-06T00:10:00+00:00",
+                    "state": "MERGED",
+                }
+            ],
+            "labels": ["type:task", "status:in-progress", "status:done"],
+        },
+    )
+    state_dir = repo / ".aipm/state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "active-issue.json").write_text(
+        json.dumps(
+            {
+                "issue": 1,
+                "title": "[Task] Close flow",
+                "branch": "main",
+                "worktree": str(repo),
+                "repo": "owner/repo",
+                "started_at": "2026-03-06T00:00:00+00:00",
+                "updated_at": "2026-03-06T00:00:00+00:00",
+                "start_file": "",
+                "plan_file": "",
+                "progress_file": "",
+                "result_file": "docs/results/result-1-close-flow.md",
+                "status": "in_progress",
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result_path = repo / "docs/results/result-1-close-flow.md"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text("# Result\n\n## 현행화\n\n- done\n", encoding="utf-8")
+
+    proc = _run(repo, state_path, "bash", "scripts/pm-close.sh", "--from-active", "--yes")
+    assert proc.returncode == 0, proc.stderr
+    assert not (state_dir / "active-issue.json").exists()
+    assert (state_dir / "active-issue.last.json").exists()
+    assert (state_dir / "modernized-1.flag").exists()
+
+    gh_state = json.loads(state_path.read_text(encoding="utf-8"))
+    issue = gh_state["issues"][0]
+    assert issue["state"] == "CLOSED"
+    assert "status:done" in issue["labels"]
+    assert "status:in-progress" not in issue["labels"]
+
+
+def test_pm_close_auto_lands_branch_before_close(tmp_path: Path):
+    repo, state_path = _make_repo(
+        tmp_path,
+        {
+            "repo": "owner/repo",
+            "next_issue": 2,
+            "next_pr": 1,
+            "issues": [
+                {
+                    "number": 1,
+                    "title": "[Task] Land flow",
+                    "body": "body",
+                    "state": "OPEN",
+                    "url": "https://github.com/owner/repo/issues/1",
+                    "labels": ["type:task", "status:in-progress"],
+                    "updatedAt": "2026-03-06T00:00:00+00:00",
+                    "comments": [],
+                }
+            ],
+            "prs": [],
+            "labels": ["type:task", "status:in-progress", "status:done"],
+        },
+    )
+    subprocess.run(
+        ["git", "checkout", "-b", "task/PP-1-land-flow"], cwd=repo, check=True, capture_output=True
+    )
+    (repo / "feature.txt").write_text("land me\n", encoding="utf-8")
+
+    state_dir = repo / ".aipm/state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "active-issue.json").write_text(
+        json.dumps(
+            {
+                "issue": 1,
+                "title": "[Task] Land flow",
+                "branch": "task/PP-1-land-flow",
+                "worktree": str(repo),
+                "repo": "owner/repo",
+                "started_at": "2026-03-06T00:00:00+00:00",
+                "updated_at": "2026-03-06T00:00:00+00:00",
+                "start_file": "",
+                "plan_file": "",
+                "progress_file": "",
+                "result_file": "docs/results/result-1-land-flow.md",
+                "status": "in_progress",
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result_path = repo / "docs/results/result-1-land-flow.md"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text("# Result\n\n## 현행화\n\n- done\n", encoding="utf-8")
+
+    proc = _run(repo, state_path, "bash", "scripts/pm-close.sh", "--from-active", "--yes")
+    assert proc.returncode == 0, proc.stderr
+
+    gh_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert gh_state["issues"][0]["state"] == "CLOSED"
+    assert gh_state["prs"][0]["state"] == "MERGED"
+    assert (state_dir / "modernized-1.flag").exists()
+
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+    log = subprocess.run(
+        ["git", "log", "--oneline", "--", "feature.txt"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "land closeout branch" in log.stdout
+
+
+def test_pm_close_requires_result_file_in_active_worktree(tmp_path: Path):
+    repo, state_path = _make_repo(
+        tmp_path,
+        {
+            "repo": "owner/repo",
+            "next_issue": 2,
+            "next_pr": 1,
+            "issues": [
+                {
+                    "number": 1,
+                    "title": "[Task] Split worktree flow",
+                    "body": "body",
+                    "state": "OPEN",
+                    "url": "https://github.com/owner/repo/issues/1",
+                    "labels": ["type:task", "status:in-progress"],
+                    "updatedAt": "2026-03-06T00:00:00+00:00",
+                    "comments": [],
+                }
+            ],
+            "prs": [],
+            "labels": ["type:task", "status:in-progress", "status:done"],
+        },
+    )
+    subprocess.run(
+        ["git", "branch", "task/PP-1-split-worktree-flow"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    active_worktree = tmp_path / "active-worktree"
+    subprocess.run(
+        ["git", "worktree", "add", str(active_worktree), "task/PP-1-split-worktree-flow"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    state_dir = repo / ".aipm/state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "active-issue.json").write_text(
+        json.dumps(
+            {
+                "issue": 1,
+                "title": "[Task] Split worktree flow",
+                "branch": "task/PP-1-split-worktree-flow",
+                "worktree": str(active_worktree),
+                "repo": "owner/repo",
+                "started_at": "2026-03-06T00:00:00+00:00",
+                "updated_at": "2026-03-06T00:00:00+00:00",
+                "start_file": "",
+                "plan_file": "",
+                "progress_file": "",
+                "result_file": "docs/results/result-1-split-worktree-flow.md",
+                "status": "in_progress",
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result_path = repo / "docs/results/result-1-split-worktree-flow.md"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text("# Result\n\n## 현행화\n\n- done\n", encoding="utf-8")
+
+    proc = _run(repo, state_path, "bash", "scripts/pm-close.sh", "--from-active", "--yes")
+    assert proc.returncode == 2
+    assert "blocker=result_file_not_in_active_worktree:docs/results/result-1-split-worktree-flow.md" in proc.stderr
+
+
+def test_check_pm_integrity_fix_active_repairs_missing_status(tmp_path: Path):
+    repo, state_path = _make_repo(
+        tmp_path,
+        {
+            "repo": "owner/repo",
+            "next_issue": 2,
+            "next_pr": 1,
+            "issues": [
+                {
+                    "number": 1,
+                    "title": "[Task] Missing status",
+                    "body": "body",
+                    "state": "OPEN",
+                    "url": "https://github.com/owner/repo/issues/1",
+                    "labels": ["type:task"],
+                    "updatedAt": "2026-03-06T00:00:00+00:00",
+                    "comments": [],
+                }
+            ],
+            "prs": [],
+            "labels": ["type:task", "status:in-progress", "status:done"],
+        },
+    )
+    state_dir = repo / ".aipm/state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "active-issue.json").write_text(
+        json.dumps({"issue": 1}, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    proc = _run(
+        repo, state_path, "bash", "scripts/check-pm-integrity.sh", "--state", "open", "--fix-active"
+    )
+    assert proc.returncode == 0, proc.stderr
+    gh_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert "status:in-progress" in gh_state["issues"][0]["labels"]


### PR DESCRIPTION
## Summary
- promote the new PM lifecycle into the public aipm-ops baseline
- add active issue state helpers and land+close semantics
- update bootstrap-managed guardrails and tests

## Verification
- bash -n scripts/pm-state.sh scripts/pm-start.sh scripts/pm-sync.sh scripts/pm-close.sh scripts/pm-modernize.sh scripts/check-pm-integrity.sh scripts/aipm-bootstrap-repo.sh
- pytest -q tests/e2e/test_pm_issue_ops.py

Refs #0